### PR TITLE
fix(ci): prevent code injection in issue-notification workflow

### DIFF
--- a/.github/workflows/issue-notification.yml
+++ b/.github/workflows/issue-notification.yml
@@ -8,13 +8,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Send to Slack
+        env:
+          SLACK_ISSUE_WEBHOOK_URL: ${{ secrets.SLACK_ISSUE_WEBHOOK_URL }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_ACTION: ${{ github.event.action }}
+          ISSUE_USER: ${{ github.event.issue.user.login }}
+          REPO_NAME: ${{ github.event.repository.full_name }}
         run: |
-          curl -X POST "${{ secrets.SLACK_ISSUE_WEBHOOK_URL }}" \
+          payload="$(jq -n \
+            --arg issue_url "$ISSUE_URL" \
+            --arg issue_title "$ISSUE_TITLE" \
+            --arg action "$ISSUE_ACTION" \
+            --arg user "$ISSUE_USER" \
+            --arg repo_name "$REPO_NAME" \
+            '{issue_url: $issue_url, issue_title: $issue_title, action: $action, user: $user, repo_name: $repo_name}')"
+          curl -X POST "$SLACK_ISSUE_WEBHOOK_URL" \
             -H "Content-Type: application/json" \
-            -d '{
-              "issue_url": "${{ github.event.issue.html_url }}",
-              "issue_title": "${{ github.event.issue.title }}",
-              "action": "${{ github.event.action }}",
-              "user": "${{ github.event.issue.user.login }}",
-              "repo_name": "${{ github.event.repository.full_name }}"
-            }'
+            -d "$payload"


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-bench/aws-bench/security/code-scanning/4

*Description of changes:*
Pass untrusted github.event.issue fields via env vars and build the Slack payload with jq --arg instead of interpolating them directly into the run: script.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
