### PR TITLE
fix(ci): skip PR Slack notification for Dependabot

### DIFF
--- a/.github/workflows/pr-notification.yml
+++ b/.github/workflows/pr-notification.yml
@@ -7,6 +7,7 @@ permissions: {}
 
 jobs:
   notify:
+    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
       - name: Send to Slack
@@ -18,6 +19,10 @@ jobs:
           PR_USER: ${{ github.event.pull_request.user.login }}
           REPO_NAME: ${{ github.event.repository.full_name }}
         run: |
+          if [ -z "$SLACK_WEBHOOK_URL" ]; then
+            echo "SLACK_WEBHOOK_URL is not set; skipping notification." >&2
+            exit 0
+          fi
           payload="$(jq -n \
             --arg pr_url "$PR_URL" \
             --arg pr_title "$PR_TITLE" \
@@ -25,6 +30,6 @@ jobs:
             --arg user "$PR_USER" \
             --arg repo_name "$REPO_NAME" \
             '{pr_url: $pr_url, pr_title: $pr_title, action: $action, user: $user, repo_name: $repo_name}')"
-          curl -X POST "$SLACK_WEBHOOK_URL" \
+          curl -sSf -X POST "$SLACK_WEBHOOK_URL" \
             -H "Content-Type: application/json" \
             -d "$payload"


### PR DESCRIPTION
Dependabot PRs run in a locked-down context where repo secrets are withheld, so SLACK_WEBHOOK_URL resolved to empty and curl failed with a malformed-URL error. Skip the notify job for dependabot[bot] and guard against an empty webhook URL for fork PRs.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
