### PR TITLE
chore(registry): bump datasets for api-and-observability update

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "api-and-observability",
-    "version": "0.7.0",
+    "version": "0.7.1",
     "description": "Multi-service environment with OpenSearch, ECS, Lambda, API Gateway, CloudFront, Redshift, Step Functions, Bedrock, and ELBv2 across us-east-1, us-west-2, and ap-southeast-1; 15 aws-introspection tasks against api-and-observability.",
     "tasks": [
       {
@@ -99,7 +99,7 @@
       {
         "name": "api-and-observability",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "3c5e9dcce9a1211cfd3d4484ffa587bcb2d0763e",
+        "git_commit_id": "2daf77d2d41c21bae00bf8227fc463be51f721d0",
         "path": "scenarios/api-and-observability"
       }
     ],
@@ -1192,7 +1192,7 @@
   },
   {
     "name": "aws-bench-advanced",
-    "version": "0.7.0",
+    "version": "0.7.1",
     "description": "Hard-tier launch dataset (phase 1): 47 introspection tasks across reference-architectures, api-and-observability, and troubleshooting-multiservice.",
     "tasks": [
       {
@@ -1488,7 +1488,7 @@
       {
         "name": "api-and-observability",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "3c5e9dcce9a1211cfd3d4484ffa587bcb2d0763e",
+        "git_commit_id": "2daf77d2d41c21bae00bf8227fc463be51f721d0",
         "path": "scenarios/api-and-observability"
       },
       {
@@ -2046,7 +2046,7 @@
   },
   {
     "name": "all",
-    "version": "0.7.0",
+    "version": "0.7.1",
     "description": "Unified dataset spanning 8 scenario(s) (api-and-observability, compute-and-data, databases-and-storage, ec2-multiregion, reference-architectures, serverless-apps, streaming-and-iot, troubleshooting-multiservice): 8 scenarios, 134 tasks.",
     "tasks": [
       {
@@ -2858,7 +2858,7 @@
       {
         "name": "api-and-observability",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "3c5e9dcce9a1211cfd3d4484ffa587bcb2d0763e",
+        "git_commit_id": "2daf77d2d41c21bae00bf8227fc463be51f721d0",
         "path": "scenarios/api-and-observability"
       },
       {


### PR DESCRIPTION
Repoint the api-and-observability scenario to dataset commit 2daf77d (was 3c5e9dc) and bump the api-and-observability, aws-bench-advanced, and all datasets from 0.7.0 to 0.7.1.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
