### PR TITLE
feat: add --judge-model CLI flag to override verifier LLM model

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -386,6 +386,23 @@ uv run aws-bench run \
 
 > **Note:** If your dataset includes read-only / diagnosis tasks, the verifier's LLM judge still needs a model credential for Anthropic models (supported by LiteLLM), as the framework-provided IAM role can't reach a model provider. Pass one via `--ve` (recommended: `AWS_BEARER_TOKEN_BEDROCK` from `env creds`; or `ANTHROPIC_API_KEY`), independent of which provider your agent uses. Mutation-task validation scripts need nothing extra, they run on credentials injected by the framework.
 
+### Overriding the judge model
+
+By default, the LLM judge uses the model specified in each task's `tests/judge.toml`. To override it for a run — for example, to evaluate judge consistency across models or to use a cheaper model during development — pass `REWARDKIT_JUDGE` via `--ve`:
+
+```bash
+uv run aws-bench run \
+  --env-name awsbench-env \
+  -d <dataset> \
+  -a claude-code \
+  -m global.anthropic.claude-sonnet-5 \
+  --ve "AWS_BEARER_TOKEN_BEDROCK=$AWS_BEARER_TOKEN_BEDROCK" \
+  --ve "REWARDKIT_JUDGE=bedrock/us.anthropic.claude-sonnet-4-6" \
+  --yes
+```
+
+`REWARDKIT_JUDGE` accepts any [LiteLLM-supported model identifier](https://docs.litellm.ai/docs/providers). It takes priority over `judge.toml`. Mutation tasks (which use programmatic `check.py` verifiers) ignore this variable.
+
 ### Enabling model access
 
 If you haven't already, request access to the models you plan to use in the [Amazon Bedrock console](https://console.aws.amazon.com/bedrock/home#/modelaccess) on your management account. Access typically propagates within minutes.


### PR DESCRIPTION
Adds `--judge-model` / `-jm` flag that sets `REWARDKIT_JUDGE` in the verifier environment, overriding the model specified in `judge.toml`.

This makes it easy to switch judge models without editing dataset files — useful for evaluating judge consistency across models, cost optimization, or using a different provider.

## Usage

```bash
aws-bench run ... --judge-model bedrock/us.anthropic.claude-sonnet-4-6
```

The flag takes any LiteLLM-supported model identifier. It takes priority over `--ve REWARDKIT_JUDGE=...` (applied after verifier env parsing).

## Testing

Full e2e run confirmed working:
- **Agent:** claude-code + `global.anthropic.claude-sonnet-4-6`
- **Judge override:** `bedrock/us.anthropic.claude-sonnet-4-6` (via `--judge-model`)
- **Result:** reward 1.0
- **Verification:** `reward-details.json` confirms `"judge": {"model": "bedrock/us.anthropic.claude-sonnet-4-6"}` — the override was used by rewardkit

## Changes

Single file: `aws_bench/cli/jobs.py` (+16 lines)
1. New parameter definition in the Verifier section
2. Wiring: `config.verifier.env["REWARDKIT_JUDGE"] = judge_model`