### PR TITLE
fix(cleanup): make MediaLive channels, inputs and security groups deletable

### DIFF
--- a/aws_bench/resource_management/cleanup/handlers/medialive.py
+++ b/aws_bench/resource_management/cleanup/handlers/medialive.py
@@ -1,29 +1,348 @@
-"""MediaLive cleanup handlers.
+"""MediaLive cleanup handlers — Channel → Input → InputSecurityGroup, none CCAPI-deletable.
 
-CloudControl does not expose a delete for ``AWS::MediaLive::InputSecurityGroup`` (the type is
-NON_PROVISIONABLE), so a scanned security group is otherwise undeletable. The fast-scan lister emits
-the CCAPI primary identifier ``Id``, which is exactly the arg ``delete_input_security_group`` wants.
+The custom-delete wave is unordered, so each handler deletes its own blockers. Deletes are
+tombstoned (``delete_*`` 200s, ``describe_*`` keeps serving), so ``State == "DELETED"`` is the
+gone-signal, not ``NotFoundException``, and every delete is safe to re-issue. Each loop
+re-describes before acting, so blockers are re-derived per poll rather than read once.
+
+Contract (as for ``ipam``): CONFIRMED gone (DELETED / never existed) or FAILED.
 """
 
 from __future__ import annotations
 
-import boto3
+import time
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass, field
 
+import boto3
+from botocore.client import BaseClient
+from botocore.exceptions import BotoCoreError, ClientError
+
+from aws_bench.logging.logger import get_logger
 from aws_bench.resource_management.ccapi.models import Resource
 from aws_bench.resource_management.cleanup.handler_registry import resource_handler
-from aws_bench.resource_management.cleanup.handlers._service_delete import service_delete
-from aws_bench.resource_management.cleanup.models import HandlerResult
+from aws_bench.resource_management.cleanup.models import HandlerResult, HandlerStatus
+from aws_bench.utils.concurrent import build_client, raise_if_shutdown
+
+logger = get_logger(__name__)
+
+_NOT_FOUND_CODES = ("NotFoundException",)
+_DELETED_STATE = "DELETED"
+
+# Faults that fail identically however often they are re-issued, so the loop stops rather
+# than spending its budget on a 4xx it cannot clear.
+_PERMANENT_ERROR_CODES = frozenset(
+    {"BadRequestException", "ForbiddenException", "UnprocessableEntityException"}
+)
+
+# StopChannel is valid only from these; IDLE and *_FAILED delete directly. Transient states
+# (CREATING, UPDATING, STOPPING) are absent by design — the loop re-reads and stops once the
+# channel becomes stoppable, rather than depending on this set being exhaustive.
+_CHANNEL_LIVE_STATES = frozenset({"RUNNING", "STARTING", "RECOVERING"})
+
+_POLL_INTERVAL_SEC = 10
+_RAMP_STEP_SEC = 0.5  # a DETACHED input reaches DELETED in ~1.5s, so open far tighter
+# One budget per handler invocation, shared by every nested delete: a live channel drains its
+# pipelines for ~600s and an input may sit behind two of them.
+_HANDLER_BUDGET_SEC = 1800
+
+
+@dataclass(frozen=True)
+class ResourceApi:
+    """The describe/delete op pair for one MediaLive type, so the polling can be shared."""
+
+    describe_op: str
+    delete_op: str
+    id_param: str
+    label: str
+
+
+CHANNEL_API = ResourceApi("describe_channel", "delete_channel", "ChannelId", "channel")
+INPUT_API = ResourceApi("describe_input", "delete_input", "InputId", "input")
+ISG_API = ResourceApi(
+    "describe_input_security_group",
+    "delete_input_security_group",
+    "InputSecurityGroupId",
+    "input security group",
+)
+
+
+@dataclass(frozen=True)
+class DeleteConfirmation:
+    """Whether a resource was confirmed gone, plus the message to report either way."""
+
+    confirmed: bool
+    message: str
+    never_existed: bool = False
+
+
+# Clears what blocks a resource's delete, given its id and freshly-read description.
+BlockerClearer = Callable[[str, dict], None]
+
+
+def _error_code(fault: Exception) -> str:
+    """Return an AWS error code, or the exception class for a non-AWS fault."""
+    if isinstance(fault, ClientError):
+        return fault.response.get("Error", {}).get("Code", "")
+    return type(fault).__name__
+
+
+def _poll_gaps() -> Iterator[float]:
+    """Yield sleep gaps opening at the ramp step and widening to the poll interval.
+
+    A teardown usually settles in seconds, so a flat interval would dominate the fast case.
+    """
+    gap = _RAMP_STEP_SEC
+    while True:
+        yield gap
+        gap = min(gap + _RAMP_STEP_SEC, _POLL_INTERVAL_SEC)
+
+
+@dataclass
+class _FaultLog:
+    """Records the faults a retry loop swallows, logging each distinct code once.
+
+    Otherwise the loop is silent for its whole budget, or spams one line per poll.
+    """
+
+    label: str
+    resource_id: str
+    last: Exception | None = None
+    _logged_codes: set[str] = field(default_factory=set)
+
+    def record(self, fault: Exception) -> None:
+        """Remember the fault and log it if its code has not been seen yet."""
+        self.last = fault
+        code = _error_code(fault)
+        if code in self._logged_codes:
+            return
+        self._logged_codes.add(code)
+        logger.warning(
+            f"MediaLive {self.label} '{self.resource_id}' not deleted yet ({code}), retrying: "
+            f"{fault}"
+        )
+
+
+def _describe(client: BaseClient, api: ResourceApi, resource_id: str) -> dict:
+    """Return the describe response; only a never-existed id raises (a deleted one is served)."""
+    return getattr(client, api.describe_op)(**{api.id_param: resource_id})
+
+
+def _never_existed(fault: Exception) -> bool:
+    """Return True if the fault says the id does not exist in this account and region."""
+    return _error_code(fault) in _NOT_FOUND_CODES
+
+
+def _sleep_before_next_poll(deadline: float, gaps: Iterator[float]) -> bool:
+    """Wait for the next poll, returning False once the shared deadline leaves no time."""
+    raise_if_shutdown()
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        return False
+    time.sleep(min(next(gaps), remaining))
+    return True
+
+
+def _delete_and_confirm_gone(
+    client: BaseClient,
+    api: ResourceApi,
+    resource_id: str,
+    *,
+    deadline: float,
+    clear_blockers: BlockerClearer | None = None,
+) -> DeleteConfirmation:
+    """Delete the resource and poll until it is DELETED, or FAIL — never an unconfirmed defer.
+
+    Re-describes every pass, so ``clear_blockers`` acts on fresh state and an unreadable
+    resource is retried rather than mistaken for gone. A permanent fault stops at once.
+    """
+    faults = _FaultLog(api.label, resource_id)
+    gaps = _poll_gaps()
+    recheck_at_once = False
+
+    while True:
+        try:
+            described = _describe(client, api, resource_id)
+        except (ClientError, BotoCoreError) as fault:
+            if _never_existed(fault):
+                return DeleteConfirmation(
+                    True, f"MediaLive {api.label} does not exist", never_existed=True
+                )
+            faults.record(fault)
+        else:
+            if described.get("State", "") == _DELETED_STATE:
+                logger.debug(f"MediaLive {api.label} '{resource_id}' confirmed deleted")
+                return DeleteConfirmation(True, f"MediaLive {api.label} deleted")
+            if clear_blockers is not None:
+                clear_blockers(resource_id, described)
+            accepted = _submit_delete(client, api, resource_id, faults)
+            if accepted.permanent_fault is not None:
+                return DeleteConfirmation(
+                    False,
+                    f"MediaLive {api.label} '{resource_id}' cannot be deleted: "
+                    f"{accepted.permanent_fault}",
+                )
+            # A resource that deletes outright (a DETACHED input goes in ~1.5s) is confirmed
+            # without waiting; the skip happens once, so a slow one still settles into the ramp.
+            if accepted.submitted and not recheck_at_once:
+                recheck_at_once = True
+                continue
+
+        if not _sleep_before_next_poll(deadline, gaps):
+            reason = f": {faults.last}" if faults.last is not None else " within budget"
+            return DeleteConfirmation(
+                False, f"MediaLive {api.label} '{resource_id}' not confirmed deleted{reason}"
+            )
+
+
+@dataclass(frozen=True)
+class _DeleteAttempt:
+    """Whether the delete was accepted, and the permanent fault to stop the loop on."""
+
+    submitted: bool = False
+    permanent_fault: Exception | None = None
+
+
+def _submit_delete(
+    client: BaseClient, api: ResourceApi, resource_id: str, faults: _FaultLog
+) -> _DeleteAttempt:
+    """Issue the delete, recording a transient rejection and surfacing a permanent one."""
+    try:
+        getattr(client, api.delete_op)(**{api.id_param: resource_id})
+    except (ClientError, BotoCoreError) as fault:
+        if _never_existed(fault):
+            return _DeleteAttempt()  # The confirming read rules on this, not the delete.
+        if _error_code(fault) in _PERMANENT_ERROR_CODES:
+            return _DeleteAttempt(permanent_fault=fault)
+        faults.record(fault)
+        return _DeleteAttempt()
+    return _DeleteAttempt(submitted=True)
+
+
+def _result(resource: Resource, action: str, status: HandlerStatus, message: str) -> HandlerResult:
+    """Build a HandlerResult for *resource* (keeps the handlers below to one statement)."""
+    return HandlerResult(
+        resource_id=resource.identifier,
+        resource_type=resource.type,
+        action=action,
+        status=status,
+        message=message,
+    )
+
+
+def _confirmation_result(resource: Resource, confirmation: DeleteConfirmation) -> HandlerResult:
+    """Map a confirm-gone outcome to the handler contract (as for ``ipam``).
+
+    Gone is SUCCESS, or SKIPPED when there was nothing to delete; anything unconfirmed FAILS.
+    """
+    if not confirmation.confirmed:
+        return _result(resource, "delete", HandlerStatus.FAILED, confirmation.message)
+    status = HandlerStatus.SKIPPED if confirmation.never_existed else HandlerStatus.SUCCESS
+    return _result(resource, "delete", status, confirmation.message)
+
+
+@dataclass
+class BlockerReaper:
+    """Deletes the resources blocking a delete, on one shared budget.
+
+    One instance per handler invocation, never shared across the wave's threads. Confirmed
+    deletions are memoized: inputs routinely share a channel, and DELETED is terminal.
+    """
+
+    client: BaseClient
+    deadline: float
+    _confirmed_gone: set[tuple[str, str]] = field(default_factory=set)
+
+    def stop_channel_if_live(self, channel_id: str, described: dict) -> None:
+        """Stop the channel when it is live, so DeleteChannel is accepted (never raises).
+
+        Re-run per poll on fresh state, so a channel UPDATING at entry is still stopped later.
+        """
+        if described.get("State", "") not in _CHANNEL_LIVE_STATES:
+            return
+
+        try:
+            self.client.stop_channel(ChannelId=channel_id)
+            logger.debug(f"Stopping MediaLive channel '{channel_id}' to delete it")
+        except (ClientError, BotoCoreError) as e:
+            # A channel that raced into STOPPING rejects a second stop; the loop re-checks.
+            logger.debug(f"Could not stop MediaLive channel '{channel_id}': {e}")
+
+    def release_input(self, input_id: str, described: dict) -> None:
+        """Delete the channels pinning the input, since an ATTACHED input rejects DeleteInput.
+
+        A channel must reach DELETED to release its input, so each is confirmed, not just asked.
+        """
+        for channel_id in described.get("AttachedChannels", []):
+            self.delete_channel(channel_id)
+
+    def drain_group(self, group_id: str, described: dict) -> None:
+        """Delete the inputs referencing the security group; any of them blocks its delete.
+
+        DETACHED inputs block it too, so every referencing input goes, reaped or not.
+        """
+        for input_id in described.get("Inputs", []):
+            self.delete_input(input_id)
+
+    def delete_channel(self, channel_id: str) -> DeleteConfirmation:
+        """Stop the channel if needed, delete it, and confirm it reached DELETED."""
+        return self.reap(CHANNEL_API, channel_id, self.stop_channel_if_live)
+
+    def delete_input(self, input_id: str) -> DeleteConfirmation:
+        """Delete the input and the channels pinning it, and confirm it reached DELETED."""
+        return self.reap(INPUT_API, input_id, self.release_input)
+
+    def reap(
+        self, api: ResourceApi, resource_id: str, clear_blockers: BlockerClearer
+    ) -> DeleteConfirmation:
+        """Delete one resource against the shared deadline, at most once per invocation."""
+        memo_key = (api.label, resource_id)
+        if memo_key in self._confirmed_gone:
+            return DeleteConfirmation(True, f"MediaLive {api.label} deleted")
+
+        confirmation = _delete_and_confirm_gone(
+            self.client, api, resource_id, deadline=self.deadline, clear_blockers=clear_blockers
+        )
+        if confirmation.confirmed:
+            self._confirmed_gone.add(memo_key)
+        else:
+            logger.warning(f"MediaLive {api.label} not deleted: {confirmation.message}")
+        return confirmation
+
+
+def _reaper(session: boto3.Session) -> BlockerReaper:
+    """Build the reaper that owns this handler invocation's whole budget.
+
+    No prepare handler is registered: the registry chains prepare into delete, so one would
+    only repeat the loop's own blocker-clearing on a second budget.
+    """
+    client = build_client(session, "medialive")
+    return BlockerReaper(client, time.monotonic() + _HANDLER_BUDGET_SEC)
+
+
+# ── Registered delete handlers ───────────────────────────────────────
+
+
+@resource_handler("AWS::MediaLive::Channel", role="delete")
+def _delete_channel(resource: Resource, session: boto3.Session) -> HandlerResult:
+    """Stop the channel if it is live, delete it, and confirm it reached DELETED.
+
+    Confirming DELETED is the point: that is when the channel releases its inputs.
+    """
+    reaper = _reaper(session)
+    return _confirmation_result(resource, reaper.delete_channel(resource.identifier))
+
+
+@resource_handler("AWS::MediaLive::Input", role="delete")
+def _delete_input(resource: Resource, session: boto3.Session) -> HandlerResult:
+    """Delete the channels attached to the input, then the input, and confirm it is DELETED."""
+    reaper = _reaper(session)
+    return _confirmation_result(resource, reaper.delete_input(resource.identifier))
 
 
 @resource_handler("AWS::MediaLive::InputSecurityGroup", role="delete")
 def _delete_input_security_group(resource: Resource, session: boto3.Session) -> HandlerResult:
-    return service_delete(
-        resource,
-        session,
-        client_name="medialive",
-        op_name="delete_input_security_group",
-        id_param="InputSecurityGroupId",
-        not_found_codes=("NotFoundException",),
-        already_gone_message="Input security group already gone",
-        log_label="MediaLive input security group",
-    )
+    """Delete the inputs referencing the group, then the group, and confirm it is DELETED."""
+    reaper = _reaper(session)
+    confirmation = reaper.reap(ISG_API, resource.identifier, reaper.drain_group)
+    return _confirmation_result(resource, confirmation)

--- a/aws_bench/task/aws_trial.py
+++ b/aws_bench/task/aws_trial.py
@@ -173,8 +173,10 @@ class AwsBenchSingleStepTrial(SingleStepTrial):
         file ownership match the consuming process) with one static-credential
         profile per account tag. Yields the credential-chain env vars emptied to
         ``""`` so a host-forwarded credential set cannot outrank the file, plus
-        ``AWS_PROFILE`` set to the first tag. Removed on exit so a later stage in
-        the same container never inherits these credentials.
+        ``AWS_PROFILE`` set to the first tag. For the agent role only,
+        ``AWS_REGION``/``AWS_DEFAULT_REGION`` are pinned to the scenario's first
+        declared region. Removed on exit so a later stage in the same container
+        never inherits these credentials.
 
         Raises:
             RuntimeError: if the account mapping is empty, the credentials body
@@ -211,6 +213,11 @@ class AwsBenchSingleStepTrial(SingleStepTrial):
         tag = next(iter(self.config.account_mapping))
         cred_env["AWS_PROFILE"] = tag
         cred_env["AWS_DEFAULT_PROFILE"] = tag
+        # Agent only: pre/post-invoke and verifier scripts declare their own
+        # regions in task.toml [*.env], which this would otherwise override.
+        if role_type is RoleType.AGENT:
+            cred_env["AWS_REGION"] = self.config.regions[0]
+            cred_env["AWS_DEFAULT_REGION"] = self.config.regions[0]
 
         try:
             yield cred_env

--- a/aws_bench/task/job.py
+++ b/aws_bench/task/job.py
@@ -288,6 +288,7 @@ class AwsBenchJob(Job):
             scenario_id=scenario_id,
             concurrency_mode=task.config.concurrency.mode,
             account_mapping=mapping,
+            regions=regions,
             exports=exports,
             verify_env=self.config.verify,
         )

--- a/aws_bench/task/trial_config.py
+++ b/aws_bench/task/trial_config.py
@@ -33,6 +33,9 @@ class AwsBenchTrialConfig(TrialConfig):
     scenario_id: str
     concurrency_mode: ConcurrencyMode
     account_mapping: dict[str, str]
+    # The scenario manifest's declared regions (validated non-empty). regions[0]
+    # pins AWS_REGION/AWS_DEFAULT_REGION for the agent phase.
+    regions: list[str]
     # When False (--no-verify-env), skip the per-trial AccountContaminated tag
     # check so operators can force a run against a flagged account.
     verify_env: bool = True

--- a/tests/resource_management/cleanup/test_handlers_medialive.py
+++ b/tests/resource_management/cleanup/test_handlers_medialive.py
@@ -1,24 +1,932 @@
-"""Tests for the MediaLive cleanup handler."""
+"""Tests for the MediaLive cleanup handlers (Channel → Input → InputSecurityGroup)."""
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+import copy
+import logging
+import threading
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from unittest.mock import MagicMock, patch
+
+from botocore.exceptions import BotoCoreError, ClientError
 
 from aws_bench.resource_management.ccapi.models import Resource
-from aws_bench.resource_management.cleanup.handler_registry import CUSTOM_DELETION_REGISTRY
+from aws_bench.resource_management.cleanup.handler_registry import (
+    CUSTOM_DELETION_REGISTRY,
+    PREPARE_REGISTRY,
+)
+from aws_bench.resource_management.cleanup.handlers import medialive
 from aws_bench.resource_management.cleanup.models import HandlerStatus
+from aws_bench.resource_management.cleanup.resource_cleaner import ResourceCleaner
+
+_CHANNEL_TYPE = "AWS::MediaLive::Channel"
+_INPUT_TYPE = "AWS::MediaLive::Input"
+_ISG_TYPE = "AWS::MediaLive::InputSecurityGroup"
+
+# The ids that leaked in the scheduled-runner run this module fixes.
+_INPUT_ID = "1592653"
+_OTHER_INPUT_ID = "4887889"
+_ISG_ID = "44476"
+_CHANNEL_ID = "9876543"
+
+_ISG_CONFLICT = (
+    f"Input Security Group {_ISG_ID} cannot be deleted because it is still being used by inputs."
+)
 
 
-def test_delete_input_security_group_via_registry():
-    """The handler deletes by the emitted InputSecurityGroup Id (the CCAPI primary identifier)."""
-    session = MagicMock()
-    client = MagicMock()
-    session.client.return_value = client
+class VirtualClock:
+    """A per-thread virtual clock: ``sleep`` advances time instead of passing.
 
-    handler = CUSTOM_DELETION_REGISTRY.get("AWS::MediaLive::InputSecurityGroup")
-    assert handler is not None
-    result = handler(
-        Resource(type="AWS::MediaLive::InputSecurityGroup", identifier="9589704"), session
-    )
-    assert result.status is HandlerStatus.SUCCESS
-    client.delete_input_security_group.assert_called_once_with(InputSecurityGroupId="9589704")
+    Lets the real confirm loops be exercised instantly. Thread-local because
+    ``_custom_delete`` uses a pool, and one worker's sleep must not burn another's budget.
+    """
+
+    def __init__(self) -> None:
+        self._local = threading.local()
+        self.sleeps: list[float] = []
+        self._lock = threading.Lock()
+
+    def monotonic(self) -> float:
+        """Return this thread's virtual now (each thread starts at zero)."""
+        return getattr(self._local, "now", 0.0)
+
+    def sleep(self, seconds: float) -> None:
+        """Advance this thread's clock and record the gap asked for."""
+        self._local.now = self.monotonic() + seconds
+        with self._lock:
+            self.sleeps.append(seconds)
+
+
+@contextmanager
+def _instant_polling() -> Iterator[VirtualClock]:
+    """Run the handlers on a virtual clock, yielding it so tests can assert the sleep ramp.
+
+    Swaps only the handler module's ``time`` reference, so nothing else sees a frozen clock.
+    """
+    clock = VirtualClock()
+    with patch.object(medialive, "time", clock):
+        yield clock
+
+
+def _client_error(code: str, message: str, op: str) -> ClientError:
+    return ClientError({"Error": {"Code": code, "Message": message}}, op)
+
+
+@dataclass
+class FakeMediaLive:
+    """In-memory MediaLive whose deletes honour the live-verified teardown semantics.
+
+    Models the traps the handlers must survive: deleted ids linger as ``State == "DELETED"``
+    tombstones and re-delete 200s, an ATTACHED input rejects DeleteInput, any live input
+    blocks DeleteInputSecurityGroup, and only a DELETED channel releases its inputs.
+    """
+
+    inputs: dict[str, dict] = field(default_factory=dict)
+    channels: dict[str, dict] = field(default_factory=dict)
+    groups: dict[str, dict] = field(default_factory=dict)
+    client: MagicMock = field(default_factory=MagicMock)
+
+    def __post_init__(self) -> None:
+        """Wire the MagicMock client's ops to this fake's in-memory state."""
+        self.client.describe_input.side_effect = lambda InputId: self._describe(
+            self.inputs, InputId, "DescribeInput"
+        )
+        self.client.describe_channel.side_effect = lambda ChannelId: self._describe(
+            self.channels, ChannelId, "DescribeChannel"
+        )
+        self.client.describe_input_security_group.side_effect = lambda InputSecurityGroupId: (
+            self._describe(self.groups, InputSecurityGroupId, "DescribeInputSecurityGroup")
+        )
+        self.client.delete_input.side_effect = self._delete_input
+        self.client.delete_channel.side_effect = self._delete_channel
+        self.client.delete_input_security_group.side_effect = self._delete_group
+        self.client.stop_channel.side_effect = self._stop_channel
+
+    @property
+    def session(self) -> MagicMock:
+        """A boto3-session mock handing out this fake as the ``medialive`` client."""
+        session = MagicMock()
+        session.client.return_value = self.client
+        return session
+
+    def _record(self, store: dict[str, dict], resource_id: str, op: str) -> dict:
+        if resource_id not in store:
+            # Only an id that never existed in this account+region 404s.
+            raise _client_error("NotFoundException", f"{resource_id} not found", op)
+        return store[resource_id]
+
+    def _describe(self, store: dict[str, dict], resource_id: str, op: str) -> dict:
+        # Deep copy: the real API returns a fresh response, not a live handle.
+        return copy.deepcopy(self._record(store, resource_id, op))
+
+    def _delete_input(self, InputId: str) -> dict:
+        record = self._record(self.inputs, InputId, "DeleteInput")
+        if record["State"] == "ATTACHED":
+            raise _client_error(
+                "ConflictException",
+                f"Input {InputId} is busy, it cannot be deleted.",
+                "DeleteInput",
+            )
+        record["State"] = "DELETED"
+        return {}
+
+    def _delete_channel(self, ChannelId: str) -> dict:
+        record = self._record(self.channels, ChannelId, "DeleteChannel")
+        if record["State"] in ("RUNNING", "STARTING", "RECOVERING"):
+            raise _client_error(
+                "ConflictException",
+                f"Channel {ChannelId} must be idle, is {record['State']}.",
+                "DeleteChannel",
+            )
+        record["State"] = "DELETED"
+        for input_record in self.inputs.values():
+            attached = input_record.get("AttachedChannels", [])
+            if ChannelId not in attached:
+                continue
+            attached.remove(ChannelId)
+            if not attached and input_record["State"] == "ATTACHED":
+                input_record["State"] = "DETACHED"
+        return {}
+
+    def _delete_group(self, InputSecurityGroupId: str) -> dict:
+        record = self._record(self.groups, InputSecurityGroupId, "DeleteInputSecurityGroup")
+        blockers = [
+            input_id
+            for input_id in record.get("Inputs", [])
+            if self.inputs.get(input_id, {}).get("State") in ("CREATING", "DETACHED", "ATTACHED")
+        ]
+        if blockers:
+            raise _client_error("ConflictException", _ISG_CONFLICT, "DeleteInputSecurityGroup")
+        record["State"] = "DELETED"
+        return {}
+
+    def _stop_channel(self, ChannelId: str) -> dict:
+        self._record(self.channels, ChannelId, "StopChannel")["State"] = "IDLE"
+        return {}
+
+
+def _delete_via_registry(resource_type: str, identifier: str, session: MagicMock):
+    """Run the registered delete handler exactly as the cleanup wave does."""
+    handler = CUSTOM_DELETION_REGISTRY[resource_type]
+    return handler(Resource(type=resource_type, identifier=identifier), session)
+
+
+def _reaper(client: MagicMock, budget: float | None = None) -> medialive.BlockerReaper:
+    """A reaper on the virtual clock's budget, as a handler invocation would build it."""
+    budget = medialive._HANDLER_BUDGET_SEC if budget is None else budget
+    return medialive.BlockerReaper(client, medialive.time.monotonic() + budget)
+
+
+# -- registration: all three types need a delete path, none is CCAPI-deletable --
+
+
+class TestRegistration:
+    def test_all_three_types_have_a_delete_handler(self):
+        for resource_type in (_CHANNEL_TYPE, _INPUT_TYPE, _ISG_TYPE):
+            assert resource_type in CUSTOM_DELETION_REGISTRY
+
+    def test_no_prepare_handler_doubles_the_budget(self):
+        """Each delete clears its own blockers, so a chained prepare would only repeat it."""
+        for resource_type in (_CHANNEL_TYPE, _INPUT_TYPE, _ISG_TYPE):
+            assert resource_type not in PREPARE_REGISTRY
+
+
+# -- AWS::MediaLive::Input --
+
+
+class TestDeleteInput:
+    def test_detached_input_deletes(self):
+        fake = FakeMediaLive(inputs={_INPUT_ID: {"State": "DETACHED", "AttachedChannels": []}})
+        with _instant_polling():
+            result = _delete_via_registry(_INPUT_TYPE, _INPUT_ID, fake.session)
+
+        assert result.status is HandlerStatus.SUCCESS
+        fake.client.delete_input.assert_called_once_with(InputId=_INPUT_ID)
+        fake.client.delete_channel.assert_not_called()
+        assert fake.inputs[_INPUT_ID]["State"] == "DELETED"
+
+    def test_attached_input_deletes_its_blocking_channel_first(self):
+        fake = FakeMediaLive(
+            inputs={_INPUT_ID: {"State": "ATTACHED", "AttachedChannels": [_CHANNEL_ID]}},
+            channels={_CHANNEL_ID: {"State": "IDLE"}},
+        )
+        with _instant_polling():
+            result = _delete_via_registry(_INPUT_TYPE, _INPUT_ID, fake.session)
+
+        assert result.status is HandlerStatus.SUCCESS
+        fake.client.delete_channel.assert_called_once_with(ChannelId=_CHANNEL_ID)
+        fake.client.stop_channel.assert_not_called()  # IDLE deletes directly
+        assert fake.channels[_CHANNEL_ID]["State"] == "DELETED"
+        assert fake.inputs[_INPUT_ID]["State"] == "DELETED"
+
+    def test_input_that_never_existed_is_skipped(self):
+        fake = FakeMediaLive()
+        with _instant_polling():
+            result = _delete_via_registry(_INPUT_TYPE, _INPUT_ID, fake.session)
+
+        assert result.status is HandlerStatus.SKIPPED
+        fake.client.delete_input.assert_not_called()
+
+    def test_input_stuck_attached_fails(self):
+        """A channel that never reaches DELETED must FAIL, not be reported as deleted."""
+        fake = FakeMediaLive(
+            inputs={_INPUT_ID: {"State": "ATTACHED", "AttachedChannels": [_CHANNEL_ID]}},
+            channels={_CHANNEL_ID: {"State": "IDLE"}},
+        )
+        # The channel delete never lands, so the input stays ATTACHED and busy.
+        fake.client.delete_channel.side_effect = _client_error(
+            "ConflictException", "channel busy", "DeleteChannel"
+        )
+        with _instant_polling():
+            result = _delete_via_registry(_INPUT_TYPE, _INPUT_ID, fake.session)
+
+        assert result.status is HandlerStatus.FAILED
+        assert "not confirmed deleted" in result.message
+
+
+# -- AWS::MediaLive::InputSecurityGroup --
+
+
+class TestDeleteInputSecurityGroup:
+    def test_prepare_drains_referencing_inputs_so_the_group_deletes(self):
+        """Regression for run 2f3ee360: the group leaked while its inputs still referenced it."""
+        fake = FakeMediaLive(
+            inputs={
+                _INPUT_ID: {"State": "ATTACHED", "AttachedChannels": [_CHANNEL_ID]},
+                _OTHER_INPUT_ID: {"State": "DETACHED", "AttachedChannels": []},
+            },
+            channels={_CHANNEL_ID: {"State": "IDLE"}},
+            groups={_ISG_ID: {"State": "IN_USE", "Inputs": [_INPUT_ID, _OTHER_INPUT_ID]}},
+        )
+        with _instant_polling():
+            result = _delete_via_registry(_ISG_TYPE, _ISG_ID, fake.session)
+
+        assert result.status is HandlerStatus.SUCCESS
+        assert fake.inputs[_INPUT_ID]["State"] == "DELETED"
+        assert fake.inputs[_OTHER_INPUT_ID]["State"] == "DELETED"
+        assert fake.channels[_CHANNEL_ID]["State"] == "DELETED"
+        assert fake.groups[_ISG_ID]["State"] == "DELETED"
+
+    def test_a_drain_that_cannot_clear_its_inputs_fails(self):
+        """The production shape: an input that will not go must keep the group FAILED."""
+        fake = FakeMediaLive(
+            inputs={_INPUT_ID: {"State": "DETACHED", "AttachedChannels": []}},
+            groups={_ISG_ID: {"State": "IN_USE", "Inputs": [_INPUT_ID]}},
+        )
+        fake.client.delete_input.side_effect = _client_error(
+            "ConflictException", "busy", "DeleteInput"
+        )
+        with _instant_polling():
+            result = _delete_via_registry(_ISG_TYPE, _ISG_ID, fake.session)
+
+        assert result.status is HandlerStatus.FAILED
+        assert "ConflictException" in result.message
+        assert fake.groups[_ISG_ID]["State"] == "IN_USE"
+
+    def test_conflict_that_clears_on_a_later_poll_succeeds(self):
+        session = MagicMock()
+        client = MagicMock()
+        session.client.return_value = client
+        client.describe_input_security_group.side_effect = [
+            {"State": "IN_USE", "Inputs": []},  # prepare
+            {"State": "IN_USE", "Inputs": []},  # poll after the rejected delete
+            {"State": "DELETED", "Inputs": []},  # poll after the retry landed
+        ]
+        client.delete_input_security_group.side_effect = [
+            _client_error("ConflictException", _ISG_CONFLICT, "DeleteInputSecurityGroup"),
+            {},
+        ]
+
+        with _instant_polling():
+            result = _delete_via_registry(_ISG_TYPE, _ISG_ID, session)
+
+        assert result.status is HandlerStatus.SUCCESS
+        assert client.delete_input_security_group.call_count == 2
+
+    def test_conflict_that_never_clears_fails(self):
+        session = MagicMock()
+        client = MagicMock()
+        session.client.return_value = client
+        client.describe_input_security_group.return_value = {"State": "IN_USE", "Inputs": []}
+        client.delete_input_security_group.side_effect = _client_error(
+            "ConflictException", _ISG_CONFLICT, "DeleteInputSecurityGroup"
+        )
+
+        with _instant_polling():
+            result = _delete_via_registry(_ISG_TYPE, _ISG_ID, session)
+
+        assert result.status is HandlerStatus.FAILED
+        assert "not confirmed deleted" in result.message
+        assert "ConflictException" in result.message
+
+    def test_deletes_by_the_emitted_id(self):
+        """The scanned Id is the CCAPI primary identifier, i.e. what the delete op wants."""
+        fake = FakeMediaLive(groups={_ISG_ID: {"State": "IDLE", "Inputs": []}})
+        with _instant_polling():
+            result = _delete_via_registry(_ISG_TYPE, _ISG_ID, fake.session)
+
+        assert result.status is HandlerStatus.SUCCESS
+        fake.client.delete_input_security_group.assert_called_once_with(
+            InputSecurityGroupId=_ISG_ID
+        )
+
+
+# -- AWS::MediaLive::Channel --
+
+
+class TestDeleteChannel:
+    def test_running_channel_is_stopped_first(self):
+        fake = FakeMediaLive(channels={_CHANNEL_ID: {"State": "RUNNING"}})
+        with _instant_polling():
+            result = _delete_via_registry(_CHANNEL_TYPE, _CHANNEL_ID, fake.session)
+
+        assert result.status is HandlerStatus.SUCCESS
+        fake.client.stop_channel.assert_called_once_with(ChannelId=_CHANNEL_ID)
+        fake.client.delete_channel.assert_called_once_with(ChannelId=_CHANNEL_ID)
+        assert fake.channels[_CHANNEL_ID]["State"] == "DELETED"
+
+    def test_idle_channel_is_not_stopped(self):
+        fake = FakeMediaLive(channels={_CHANNEL_ID: {"State": "IDLE"}})
+        with _instant_polling():
+            result = _delete_via_registry(_CHANNEL_TYPE, _CHANNEL_ID, fake.session)
+
+        assert result.status is HandlerStatus.SUCCESS
+        fake.client.stop_channel.assert_not_called()
+        fake.client.delete_channel.assert_called_once_with(ChannelId=_CHANNEL_ID)
+
+    def test_create_failed_channel_is_not_stopped(self):
+        fake = FakeMediaLive(channels={_CHANNEL_ID: {"State": "CREATE_FAILED"}})
+        with _instant_polling():
+            result = _delete_via_registry(_CHANNEL_TYPE, _CHANNEL_ID, fake.session)
+
+        assert result.status is HandlerStatus.SUCCESS
+        fake.client.stop_channel.assert_not_called()
+
+    def test_channel_that_never_existed_is_skipped(self):
+        fake = FakeMediaLive()
+        with _instant_polling():
+            result = _delete_via_registry(_CHANNEL_TYPE, _CHANNEL_ID, fake.session)
+
+        assert result.status is HandlerStatus.SKIPPED
+        fake.client.delete_channel.assert_not_called()
+
+
+# -- tombstone semantics --
+
+
+class TestTombstones:
+    def test_an_already_deleted_input_is_confirmed_without_re_deleting(self):
+        """The tombstone already proves it is gone, so no delete is needed at all."""
+        fake = FakeMediaLive(inputs={_INPUT_ID: {"State": "DELETED", "AttachedChannels": []}})
+        with _instant_polling():
+            result = _delete_via_registry(_INPUT_TYPE, _INPUT_ID, fake.session)
+
+        assert result.status is HandlerStatus.SUCCESS
+        fake.client.delete_input.assert_not_called()
+
+    def test_re_deleting_a_deleted_id_is_harmless(self):
+        """MediaLive returns 200 (not NotFoundException) for a delete on a DELETED id."""
+        fake = FakeMediaLive(inputs={_INPUT_ID: {"State": "DETACHED", "AttachedChannels": []}})
+        with _instant_polling():
+            first = _delete_via_registry(_INPUT_TYPE, _INPUT_ID, fake.session)
+            fake.client.delete_input(InputId=_INPUT_ID)  # a re-issue against the tombstone
+            second = _delete_via_registry(_INPUT_TYPE, _INPUT_ID, fake.session)
+
+        assert first.status is HandlerStatus.SUCCESS
+        assert second.status is HandlerStatus.SUCCESS
+        assert fake.inputs[_INPUT_ID]["State"] == "DELETED"
+
+    def test_gone_check_keys_on_deleted_state_not_on_not_found(self):
+        session = MagicMock()
+        client = MagicMock()
+        session.client.return_value = client
+        # A tombstone: describe keeps answering, so NotFoundException never arrives.
+        client.describe_input.return_value = {"State": "DELETED", "AttachedChannels": []}
+        client.delete_input.return_value = {}
+
+        with _instant_polling():
+            result = _delete_via_registry(_INPUT_TYPE, _INPUT_ID, session)
+
+        assert result.status is HandlerStatus.SUCCESS
+        assert "deleted" in result.message
+
+    def test_accepted_delete_without_a_deleted_state_fails(self):
+        """A 200 is not proof of deletion; only State == DELETED is."""
+        session = MagicMock()
+        client = MagicMock()
+        session.client.return_value = client
+        client.describe_input.return_value = {"State": "DETACHED", "AttachedChannels": []}
+        client.delete_input.return_value = {}
+
+        with _instant_polling():
+            result = _delete_via_registry(_INPUT_TYPE, _INPUT_ID, session)
+
+        assert result.status is HandlerStatus.FAILED
+        assert "not confirmed deleted" in result.message
+
+
+# -- a second pass over an already-torn-down chain must stay safe (cleanup retries) --
+
+
+class TestRepeatedPassesAreSafe:
+    def test_deleting_the_group_twice_stays_successful(self):
+        fake = FakeMediaLive(
+            inputs={_INPUT_ID: {"State": "DETACHED", "AttachedChannels": []}},
+            groups={_ISG_ID: {"State": "IN_USE", "Inputs": [_INPUT_ID]}},
+        )
+        with _instant_polling():
+            first = _delete_via_registry(_ISG_TYPE, _ISG_ID, fake.session)
+            second = _delete_via_registry(_ISG_TYPE, _ISG_ID, fake.session)
+
+        assert first.status is HandlerStatus.SUCCESS
+        assert second.status is HandlerStatus.SUCCESS
+        # The second pass sees the tombstone and re-deletes nothing.
+        assert fake.client.delete_input_security_group.call_count == 1
+        assert fake.inputs[_INPUT_ID]["State"] == "DELETED"
+
+    def test_deleting_a_running_channel_twice_stops_it_once(self):
+        fake = FakeMediaLive(channels={_CHANNEL_ID: {"State": "RUNNING"}})
+        with _instant_polling():
+            first = _delete_via_registry(_CHANNEL_TYPE, _CHANNEL_ID, fake.session)
+            second = _delete_via_registry(_CHANNEL_TYPE, _CHANNEL_ID, fake.session)
+
+        assert first.status is HandlerStatus.SUCCESS
+        assert second.status is HandlerStatus.SUCCESS
+        fake.client.stop_channel.assert_called_once_with(ChannelId=_CHANNEL_ID)
+
+    def test_deleting_an_attached_input_twice_deletes_the_channel_once(self):
+        fake = FakeMediaLive(
+            inputs={_INPUT_ID: {"State": "ATTACHED", "AttachedChannels": [_CHANNEL_ID]}},
+            channels={_CHANNEL_ID: {"State": "IDLE"}},
+        )
+        with _instant_polling():
+            first = _delete_via_registry(_INPUT_TYPE, _INPUT_ID, fake.session)
+            second = _delete_via_registry(_INPUT_TYPE, _INPUT_ID, fake.session)
+
+        assert first.status is HandlerStatus.SUCCESS
+        assert second.status is HandlerStatus.SUCCESS
+        fake.client.delete_channel.assert_called_once_with(ChannelId=_CHANNEL_ID)
+
+
+# -- the unordered custom-delete wave that leaked the group in production --
+
+
+class TestConcurrentWave:
+    def test_whole_chain_deletes_in_one_unordered_wave(self):
+        """No ordering between types, so the whole chain must go regardless of who wins."""
+        fake = FakeMediaLive(
+            inputs={
+                _INPUT_ID: {"State": "ATTACHED", "AttachedChannels": [_CHANNEL_ID]},
+                _OTHER_INPUT_ID: {"State": "DETACHED", "AttachedChannels": []},
+            },
+            channels={_CHANNEL_ID: {"State": "RUNNING"}},
+            groups={_ISG_ID: {"State": "IN_USE", "Inputs": [_INPUT_ID, _OTHER_INPUT_ID]}},
+        )
+        wave = [
+            Resource(type=_ISG_TYPE, identifier=_ISG_ID),
+            Resource(type=_INPUT_TYPE, identifier=_INPUT_ID),
+            Resource(type=_INPUT_TYPE, identifier=_OTHER_INPUT_ID),
+            Resource(type=_CHANNEL_TYPE, identifier=_CHANNEL_ID),
+        ]
+
+        with _instant_polling():
+            result = ResourceCleaner(fake.session)._custom_delete(wave)
+
+        assert result.failed == {}
+        assert sorted(r.identifier for r in result.succeeded) == sorted(r.identifier for r in wave)
+        assert fake.groups[_ISG_ID]["State"] == "DELETED"
+        assert fake.inputs[_INPUT_ID]["State"] == "DELETED"
+        assert fake.inputs[_OTHER_INPUT_ID]["State"] == "DELETED"
+        assert fake.channels[_CHANNEL_ID]["State"] == "DELETED"
+
+
+# -- a transient fault must cost one poll, never the whole pass --
+
+
+class TestTransientFaultsDoNotAbortTheDelete:
+    def test_an_unreadable_first_poll_still_deletes(self):
+        fake = FakeMediaLive(inputs={_INPUT_ID: {"State": "DETACHED", "AttachedChannels": []}})
+        fake.client.describe_input.side_effect = [
+            _client_error("TooManyRequestsException", "slow down", "DescribeInput"),
+            {"State": "DETACHED", "AttachedChannels": []},
+            {"State": "DELETED", "AttachedChannels": []},
+        ]
+        with _instant_polling():
+            result = _delete_via_registry(_INPUT_TYPE, _INPUT_ID, fake.session)
+
+        assert result.status is HandlerStatus.SUCCESS
+        fake.client.delete_input.assert_called_once_with(InputId=_INPUT_ID)
+
+    def test_a_rejected_stop_still_lets_the_channel_delete_run(self):
+        fake = FakeMediaLive(channels={_CHANNEL_ID: {"State": "RUNNING"}})
+        fake.client.stop_channel.side_effect = _client_error(
+            "ConflictException", "channel is not stoppable", "StopChannel"
+        )
+        with _instant_polling():
+            result = _delete_via_registry(_CHANNEL_TYPE, _CHANNEL_ID, fake.session)
+
+        # The stop is best-effort; the delete is what rules, and RUNNING blocks it.
+        assert result.status is HandlerStatus.FAILED
+        assert fake.client.delete_channel.call_count >= 1
+
+    def test_an_unreadable_group_read_still_deletes(self):
+        fake = FakeMediaLive(groups={_ISG_ID: {"State": "IDLE", "Inputs": []}})
+        fake.client.describe_input_security_group.side_effect = [
+            _client_error("TooManyRequestsException", "slow down", "DescribeInputSecurityGroup"),
+            {"State": "IDLE", "Inputs": []},
+            {"State": "DELETED", "Inputs": []},
+        ]
+        with _instant_polling():
+            result = _delete_via_registry(_ISG_TYPE, _ISG_ID, fake.session)
+
+        assert result.status is HandlerStatus.SUCCESS
+        fake.client.delete_input_security_group.assert_called_once_with(
+            InputSecurityGroupId=_ISG_ID
+        )
+
+
+# -- polling efficiency: a resource that settles fast must be observed fast --
+
+
+class TestPollingEfficiency:
+    def test_a_settled_resource_costs_no_sleep_at_all(self):
+        """The delete and its confirming read are one predicate pass, so nothing is waited on."""
+        fake = FakeMediaLive(inputs={_INPUT_ID: {"State": "DETACHED", "AttachedChannels": []}})
+        with _instant_polling() as clock:
+            result = _delete_via_registry(_INPUT_TYPE, _INPUT_ID, fake.session)
+
+        assert result.status is HandlerStatus.SUCCESS
+        assert clock.sleeps == []
+
+    def test_first_re_check_is_fast_not_a_full_interval(self):
+        """A resource DELETED by the second read is seen after the ramp's first step."""
+        fake = FakeMediaLive(inputs={_INPUT_ID: {"State": "SETTLING", "AttachedChannels": []}})
+        # The delete lands but the state trails it, as a real settle does.
+        fake.client.delete_input.side_effect = None
+        fake.client.delete_input.return_value = {}
+        fake.client.describe_input.side_effect = [
+            {"State": "SETTLING", "AttachedChannels": []},  # prepare's read
+            {"State": "SETTLING", "AttachedChannels": []},  # still settling
+            {"State": "DELETED", "AttachedChannels": []},
+        ]
+
+        with _instant_polling() as clock:
+            result = _delete_via_registry(_INPUT_TYPE, _INPUT_ID, fake.session)
+
+        assert result.status is HandlerStatus.SUCCESS
+        assert clock.sleeps == [medialive._RAMP_STEP_SEC]
+        assert sum(clock.sleeps) < medialive._POLL_INTERVAL_SEC
+
+    def test_ramp_widens_toward_the_interval_and_stops_there(self):
+        """Gaps grow by the ramp step each poll and cap at the interval, never hammering."""
+        session = MagicMock()
+        client = MagicMock()
+        session.client.return_value = client
+        client.describe_input.return_value = {"State": "DETACHED", "AttachedChannels": []}
+        client.delete_input.return_value = {}
+
+        with _instant_polling() as clock:
+            result = _delete_via_registry(_INPUT_TYPE, _INPUT_ID, session)
+
+        assert result.status is HandlerStatus.FAILED  # never reached DELETED
+        # The accepted delete buys one immediate re-check, then the ramp opens and widens.
+        assert clock.sleeps[:4] == [0.5, 1.0, 1.5, 2.0]
+        assert max(clock.sleeps) == medialive._POLL_INTERVAL_SEC
+        # The loop trims its last gap to the deadline, so the budget is never overshot.
+        assert sum(clock.sleeps) <= medialive._HANDLER_BUDGET_SEC
+
+    def test_a_slow_channel_still_succeeds_within_budget(self):
+        """A channel draining pipelines past the ramp is still confirmed, not timed out."""
+        session = MagicMock()
+        client = MagicMock()
+        session.client.return_value = client
+        client.describe_channel.side_effect = [{"State": "IDLE"}] * 31 + [{"State": "DELETED"}]
+        client.delete_channel.return_value = {}
+
+        with _instant_polling() as clock:
+            result = _delete_via_registry(_CHANNEL_TYPE, _CHANNEL_ID, session)
+
+        assert result.status is HandlerStatus.SUCCESS
+        assert sum(clock.sleeps) < medialive._HANDLER_BUDGET_SEC
+        client.stop_channel.assert_not_called()  # IDLE deletes directly
+
+    def test_slow_resource_polls_are_bounded_by_the_interval(self):
+        """Over a long wait the API is hit at the flat interval, not at the ramp's opening rate."""
+        session = MagicMock()
+        client = MagicMock()
+        session.client.return_value = client
+        client.describe_input_security_group.return_value = {"State": "IN_USE", "Inputs": []}
+        client.delete_input_security_group.side_effect = _client_error(
+            "ConflictException", _ISG_CONFLICT, "DeleteInputSecurityGroup"
+        )
+
+        with _instant_polling() as clock:
+            result = _delete_via_registry(_ISG_TYPE, _ISG_ID, session)
+
+        assert result.status is HandlerStatus.FAILED
+        # A flat ramp-step gap would be 3600 polls; the widening keeps it near budget/interval.
+        flat_interval_polls = medialive._HANDLER_BUDGET_SEC / medialive._POLL_INTERVAL_SEC
+        assert len(clock.sleeps) < 2 * flat_interval_polls
+
+
+# -- a blocker confirmed gone is not re-deleted or re-confirmed in the same invocation --
+
+
+class TestBlockerConfirmedOncePerInvocation:
+    def test_a_channel_already_confirmed_is_not_re_deleted(self):
+        """The second ask for a channel already seen DELETED skips the delete and the loop."""
+        fake = FakeMediaLive(channels={_CHANNEL_ID: {"State": "IDLE"}})
+        with _instant_polling():
+            reaper = _reaper(fake.client)
+            first = reaper.delete_channel(_CHANNEL_ID)
+            calls_after_first = fake.client.describe_channel.call_count
+            second = reaper.delete_channel(_CHANNEL_ID)
+
+        assert first.confirmed and second.confirmed
+        fake.client.delete_channel.assert_called_once_with(ChannelId=_CHANNEL_ID)
+        # No describe either: the memoized confirmation short-circuits the whole loop.
+        assert fake.client.describe_channel.call_count == calls_after_first
+
+    def test_two_inputs_sharing_a_channel_confirm_it_once(self):
+        """A primary/backup pair on one channel: the second release reuses the confirmation."""
+        fake = FakeMediaLive(
+            inputs={
+                _INPUT_ID: {"State": "ATTACHED", "AttachedChannels": [_CHANNEL_ID]},
+                _OTHER_INPUT_ID: {"State": "ATTACHED", "AttachedChannels": [_CHANNEL_ID]},
+            },
+            channels={_CHANNEL_ID: {"State": "IDLE"}},
+        )
+        with _instant_polling():
+            reaper = _reaper(fake.client)
+            reaper.delete_input(_INPUT_ID)
+            reaper.delete_input(_OTHER_INPUT_ID)
+
+        fake.client.delete_channel.assert_called_once_with(ChannelId=_CHANNEL_ID)
+        assert fake.channels[_CHANNEL_ID]["State"] == "DELETED"
+
+    def test_memoization_is_per_invocation_not_shared_across_calls(self):
+        """No cross-invocation cache: a fresh reaper re-reads instead of trusting the last."""
+        fake = FakeMediaLive(channels={_CHANNEL_ID: {"State": "IDLE"}})
+        with _instant_polling():
+            _reaper(fake.client).delete_channel(_CHANNEL_ID)
+            reads_after_first = fake.client.describe_channel.call_count
+            _reaper(fake.client).delete_channel(_CHANNEL_ID)
+
+        assert fake.client.describe_channel.call_count > reads_after_first
+
+    def test_an_unconfirmed_channel_is_retried_not_memoized(self):
+        """Only a confirmed-DELETED channel is memoized, so a stuck one is asked again."""
+        fake = FakeMediaLive(channels={_CHANNEL_ID: {"State": "IDLE"}})
+        fake.client.delete_channel.side_effect = _client_error(
+            "ConflictException", "channel busy", "DeleteChannel"
+        )
+        with _instant_polling():
+            reaper = _reaper(fake.client, budget=60)
+            first = reaper.delete_channel(_CHANNEL_ID)
+            calls_after_first = fake.client.delete_channel.call_count
+            second = reaper.delete_channel(_CHANNEL_ID)
+
+        assert not first.confirmed and not second.confirmed
+        assert fake.client.delete_channel.call_count > calls_after_first
+
+    def test_a_stuck_shared_channel_still_fails_the_group(self):
+        """End to end: an undeletable channel keeps the group FAILED, never papered over."""
+        fake = FakeMediaLive(
+            inputs={_INPUT_ID: {"State": "ATTACHED", "AttachedChannels": [_CHANNEL_ID]}},
+            channels={_CHANNEL_ID: {"State": "IDLE"}},
+            groups={_ISG_ID: {"State": "IN_USE", "Inputs": [_INPUT_ID]}},
+        )
+        fake.client.delete_channel.side_effect = _client_error(
+            "ConflictException", "channel busy", "DeleteChannel"
+        )
+        with _instant_polling():
+            result = _delete_via_registry(_ISG_TYPE, _ISG_ID, fake.session)
+
+        assert result.status is HandlerStatus.FAILED
+        assert fake.groups[_ISG_ID]["State"] == "IN_USE"
+
+
+# -- an unreadable state is never mistaken for gone (the contract's load-bearing branch) --
+
+
+class TestUnreadableStateIsNotGone:
+    def test_a_describe_that_never_recovers_fails(self):
+        """A permanently unreadable resource must FAIL, never be reported deleted."""
+        session = MagicMock()
+        client = MagicMock()
+        session.client.return_value = client
+        client.describe_input.side_effect = _client_error(
+            "TooManyRequestsException", "slow down", "DescribeInput"
+        )
+
+        with _instant_polling():
+            result = _delete_via_registry(_INPUT_TYPE, _INPUT_ID, session)
+
+        assert result.status is HandlerStatus.FAILED
+        assert "TooManyRequestsException" in result.message
+
+    def test_a_delete_that_404s_defers_to_the_confirming_read(self):
+        """Describe found it but delete says it never existed: the read, not the delete, rules."""
+        session = MagicMock()
+        client = MagicMock()
+        session.client.return_value = client
+        client.describe_input.side_effect = [
+            {"State": "DETACHED", "AttachedChannels": []},
+            {"State": "DELETED", "AttachedChannels": []},
+        ]
+        client.delete_input.side_effect = _client_error("NotFoundException", "gone", "DeleteInput")
+
+        with _instant_polling():
+            result = _delete_via_registry(_INPUT_TYPE, _INPUT_ID, session)
+
+        assert result.status is HandlerStatus.SUCCESS
+
+    def test_a_non_aws_fault_is_also_not_gone(self):
+        """A BotoCoreError (no error code) must not read as a not-found either."""
+        session = MagicMock()
+        client = MagicMock()
+        session.client.return_value = client
+        client.describe_input.side_effect = BotoCoreError()
+
+        with _instant_polling():
+            result = _delete_via_registry(_INPUT_TYPE, _INPUT_ID, session)
+
+        assert result.status is HandlerStatus.FAILED
+
+    def test_blockers_are_rediscovered_after_a_failed_read(self):
+        """A first-poll read fault must not lose the blocker set: the next poll re-derives it."""
+        fake = FakeMediaLive(
+            inputs={_INPUT_ID: {"State": "ATTACHED", "AttachedChannels": [_CHANNEL_ID]}},
+            channels={_CHANNEL_ID: {"State": "IDLE"}},
+        )
+        real_describe = fake.client.describe_input.side_effect
+        faults = [_client_error("TooManyRequestsException", "slow down", "DescribeInput")] * 2
+
+        def flaky(InputId: str):
+            if faults:
+                raise faults.pop()
+            return real_describe(InputId)
+
+        fake.client.describe_input.side_effect = flaky
+
+        with _instant_polling():
+            result = _delete_via_registry(_INPUT_TYPE, _INPUT_ID, fake.session)
+
+        assert result.status is HandlerStatus.SUCCESS
+        # The blocking channel was still found and deleted, despite the opening faults.
+        fake.client.delete_channel.assert_called_once_with(ChannelId=_CHANNEL_ID)
+        assert fake.inputs[_INPUT_ID]["State"] == "DELETED"
+
+
+# -- permanent faults fail fast; transient ones are retried --
+
+
+class TestErrorClassification:
+    def test_a_permanent_fault_stops_immediately(self):
+        """A 4xx that cannot clear must not burn the budget: one delete attempt, then FAIL."""
+        fake = FakeMediaLive(inputs={_INPUT_ID: {"State": "DETACHED", "AttachedChannels": []}})
+        fake.client.delete_input.side_effect = _client_error(
+            "ForbiddenException", "not authorized", "DeleteInput"
+        )
+
+        with _instant_polling() as clock:
+            result = _delete_via_registry(_INPUT_TYPE, _INPUT_ID, fake.session)
+
+        assert result.status is HandlerStatus.FAILED
+        assert "cannot be deleted" in result.message
+        assert fake.client.delete_input.call_count == 1
+        assert clock.sleeps == []  # failed fast rather than polling
+
+    def test_a_transient_fault_is_retried(self):
+        """A ConflictException is the blocker-still-present case, so it must keep trying."""
+        fake = FakeMediaLive(inputs={_INPUT_ID: {"State": "DETACHED", "AttachedChannels": []}})
+        real_delete = fake.client.delete_input.side_effect
+        rejections = [_client_error("ConflictException", "busy", "DeleteInput")] * 3
+
+        def flaky(InputId: str):
+            if rejections:
+                raise rejections.pop()
+            return real_delete(InputId)
+
+        fake.client.delete_input.side_effect = flaky
+
+        with _instant_polling():
+            result = _delete_via_registry(_INPUT_TYPE, _INPUT_ID, fake.session)
+
+        assert result.status is HandlerStatus.SUCCESS
+        assert fake.client.delete_input.call_count == 4
+
+    def test_each_distinct_fault_is_logged_once_not_per_poll(self, caplog):
+        """A retry loop must leave a trace, but one unchanged rejection must not spam the log."""
+        session = MagicMock()
+        client = MagicMock()
+        session.client.return_value = client
+        client.describe_input.return_value = {"State": "DETACHED", "AttachedChannels": []}
+        client.delete_input.side_effect = _client_error("ConflictException", "busy", "DeleteInput")
+
+        with caplog.at_level(logging.WARNING), _instant_polling():
+            result = _delete_via_registry(_INPUT_TYPE, _INPUT_ID, session)
+
+        assert result.status is HandlerStatus.FAILED
+        retry_lines = [r for r in caplog.records if "retrying" in r.getMessage()]
+        assert len(retry_lines) == 1
+        assert "ConflictException" in retry_lines[0].getMessage()
+        assert _INPUT_ID in retry_lines[0].getMessage()
+
+
+# -- the channel stop is decided on fresh state, every poll --
+
+
+class TestChannelStopStates:
+    def test_a_channel_stoppable_only_later_is_still_stopped(self):
+        """UPDATING at entry then RUNNING: the per-poll re-read is what catches it."""
+        session = MagicMock()
+        client = MagicMock()
+        session.client.return_value = client
+        client.describe_channel.side_effect = [
+            {"State": "UPDATING"},  # prepare's read: not stoppable yet
+            {"State": "UPDATING"},
+            {"State": "RUNNING"},  # now stoppable
+            {"State": "DELETED"},
+        ]
+        client.delete_channel.return_value = {}
+
+        with _instant_polling():
+            result = _delete_via_registry(_CHANNEL_TYPE, _CHANNEL_ID, session)
+
+        assert result.status is HandlerStatus.SUCCESS
+        client.stop_channel.assert_called_once_with(ChannelId=_CHANNEL_ID)
+
+    def test_transient_states_are_not_stopped(self):
+        """StopChannel is invalid from these, so it must not be issued."""
+        for state in ("IDLE", "STOPPING", "CREATING", "UPDATING", "DELETING", "UPDATE_FAILED"):
+            fake = FakeMediaLive(channels={_CHANNEL_ID: {"State": state}})
+            with _instant_polling():
+                _delete_via_registry(_CHANNEL_TYPE, _CHANNEL_ID, fake.session)
+
+            assert fake.client.stop_channel.call_count == 0, state
+
+    def test_live_states_are_stopped(self):
+        """A channel must be stopped from any of these before DeleteChannel is accepted."""
+        for state in ("RUNNING", "STARTING", "RECOVERING"):
+            fake = FakeMediaLive(channels={_CHANNEL_ID: {"State": state}})
+            with _instant_polling():
+                result = _delete_via_registry(_CHANNEL_TYPE, _CHANNEL_ID, fake.session)
+
+            assert result.status is HandlerStatus.SUCCESS, state
+            fake.client.stop_channel.assert_called_with(ChannelId=_CHANNEL_ID)
+
+
+# -- one budget per handler invocation, shared by every nested delete --
+
+
+class TestSharedBudget:
+    def test_draining_many_inputs_shares_one_budget(self):
+        """Each stuck input must draw on the same clock, not receive a fresh full budget."""
+        stuck_inputs = {
+            f"input-{i}": {"State": "DETACHED", "AttachedChannels": []} for i in range(4)
+        }
+        fake = FakeMediaLive(
+            inputs=stuck_inputs,
+            groups={_ISG_ID: {"State": "IN_USE", "Inputs": list(stuck_inputs)}},
+        )
+        # Nothing ever deletes, so every nested loop runs to the shared deadline.
+        fake.client.delete_input.side_effect = _client_error(
+            "ConflictException", "busy", "DeleteInput"
+        )
+        fake.client.delete_input_security_group.side_effect = _client_error(
+            "ConflictException", _ISG_CONFLICT, "DeleteInputSecurityGroup"
+        )
+
+        with _instant_polling() as clock:
+            result = _delete_via_registry(_ISG_TYPE, _ISG_ID, fake.session)
+
+        assert result.status is HandlerStatus.FAILED
+        # 4 inputs x a fresh budget would be 4x this; one shared deadline caps the whole handler.
+        assert sum(clock.sleeps) <= medialive._HANDLER_BUDGET_SEC
+
+    def test_an_input_reached_twice_in_one_drain_is_deleted_once(self):
+        """Two groups sharing an input, or a repeated id, must not re-run its whole loop."""
+        fake = FakeMediaLive(inputs={_INPUT_ID: {"State": "DETACHED", "AttachedChannels": []}})
+        with _instant_polling():
+            reaper = _reaper(fake.client)
+            reaper.drain_group(_ISG_ID, {"Inputs": [_INPUT_ID, _INPUT_ID]})
+
+        fake.client.delete_input.assert_called_once_with(InputId=_INPUT_ID)
+
+    def test_an_exhausted_budget_stops_the_drain(self):
+        """Once the deadline passes, no further blocker delete is attempted."""
+        fake = FakeMediaLive(
+            inputs={_INPUT_ID: {"State": "DETACHED", "AttachedChannels": []}},
+        )
+        fake.client.delete_input.side_effect = _client_error(
+            "ConflictException", "busy", "DeleteInput"
+        )
+        with _instant_polling():
+            reaper = _reaper(fake.client, budget=0)
+            confirmation = reaper.delete_input(_INPUT_ID)
+
+        assert not confirmation.confirmed
+        assert fake.client.delete_input.call_count == 1  # the opening pass only

--- a/tests/task/test_aws_trial.py
+++ b/tests/task/test_aws_trial.py
@@ -114,6 +114,7 @@ def _make_trial(
 
     trial.config = SimpleNamespace(  # type: ignore[assignment]
         account_mapping={"PRIMARY": "123456789012"},
+        regions=["us-east-1"],
         exports=exports or {},
         verifier=verifier,
         job_id=None,
@@ -317,6 +318,24 @@ async def test_run_agent_phase_sets_aws_profile_to_first_tag(tmp_path, fake_cred
 
 
 @pytest.mark.asyncio
+async def test_run_agent_phase_pins_region_to_first_scenario_region(tmp_path, fake_creds, mocker):
+    """AWS_REGION/AWS_DEFAULT_REGION are pinned to the scenario's first region."""
+    trial = _make_trial(tmp_path)
+    trial.config.regions = ["eu-west-1", "us-east-1"]  # type: ignore[attr-defined]
+    trial._aws_placeholders = {}
+
+    seen: dict[str, str] = {}
+
+    async def fake_super_phase(self, *, instruction, **kw):
+        seen.update(self.agent._extra_env)
+
+    mocker.patch.object(Trial, "_run_agent_phase", fake_super_phase)
+    await trial._run_agent_phase(target=MagicMock(), instruction="x", timeout_sec=None, user=None)
+    assert seen["AWS_REGION"] == "eu-west-1"
+    assert seen["AWS_DEFAULT_REGION"] == "eu-west-1"
+
+
+@pytest.mark.asyncio
 async def test_run_agent_phase_restores_extra_env_after_run(tmp_path, fake_creds, mocker):
     """The injected cred env is removed from _extra_env once the agent run returns."""
     trial = _make_trial(tmp_path)
@@ -493,6 +512,22 @@ async def test_prepare_runs_pre_invoke_once_and_seeds_placeholders(tmp_path, fak
     # Single account tag; pre-invoke's flat output merges under the sole tag.
     assert trial._aws_placeholders["PRIMARY"]["BucketName"] == "from-pre-invoke"
     assert trial._aws_placeholders["PRIMARY"]["Seed"] == "v"  # seed preserved
+
+
+@pytest.mark.asyncio
+async def test_pre_invoke_region_not_overridden_by_scenario_pin(tmp_path, fake_creds, mocker):
+    """The region pin is agent-only; a pre-invoke task.toml AWS_REGION survives."""
+    trial = _make_trial(
+        tmp_path, pre_invoke=_phase(env={"AWS_REGION": "us-west-2"}), has_pre_script=True
+    )
+    trial.config.regions = ["us-east-1", "us-west-2"]  # type: ignore[attr-defined]
+    runner = mocker.patch.object(aws_trial, "ScriptRunner", autospec=True)
+    runner.return_value.run = AsyncMock(return_value={})
+    mocker.patch.object(Trial, "_prepare", AsyncMock())
+
+    await trial._prepare()
+
+    assert runner.call_args.kwargs["override_env"]["AWS_REGION"] == "us-west-2"
 
 
 @pytest.mark.asyncio

--- a/tests/task/test_job.py
+++ b/tests/task/test_job.py
@@ -307,6 +307,7 @@ def test_trial_config_account_and_exports_are_real_fields():
         scenario_id="ec2-small",
         concurrency_mode=ConcurrencyMode.MUTATING,
         account_mapping={"PRIMARY": "111"},
+        regions=["us-east-1"],
         exports={"PRIMARY": {"K": "v"}},
     )
     assert cfg.account_mapping == {"PRIMARY": "111"}
@@ -372,6 +373,7 @@ def test_build_trial_config_sets_scenario_descriptor():
     )
     assert cfg.scenario is descriptor
     assert cfg.scenario_id == "ec2-small"
+    assert cfg.regions == ["us-east-1"]
 
 
 def test_build_trial_config_produces_tag_keyed_export_slice():

--- a/tests/task/test_queue.py
+++ b/tests/task/test_queue.py
@@ -114,6 +114,7 @@ def _trial_config(
         scenario_id=scenario_id,
         concurrency_mode=mode,
         account_mapping={"PRIMARY": "111111111111"},
+        regions=["us-east-1"],
     )
 
 

--- a/tests/task/test_trial_config.py
+++ b/tests/task/test_trial_config.py
@@ -25,6 +25,7 @@ def test_carries_scenario_descriptor():
         scenario=_scenario_desc(),
         scenario_id="ec2-small",
         concurrency_mode=ConcurrencyMode.MUTATING,
+        regions=["us-east-1"],
         account_mapping={"PRIMARY": "123456789012"},
     )
     assert cfg.scenario.name == "ec2-small"
@@ -38,6 +39,7 @@ def test_scenario_descriptor_rides_resume_identity():
         scenario=_scenario_desc("ec2-small"),
         scenario_id="ec2-small",
         concurrency_mode=ConcurrencyMode.MUTATING,
+        regions=["us-east-1"],
         account_mapping={"PRIMARY": "111111111111"},
     )
     diff_scenario = AwsBenchTrialConfig(
@@ -45,6 +47,7 @@ def test_scenario_descriptor_rides_resume_identity():
         scenario=_scenario_desc("ec2-large"),
         scenario_id="ec2-small",
         concurrency_mode=ConcurrencyMode.MUTATING,
+        regions=["us-east-1"],
         account_mapping={"PRIMARY": "111111111111"},
     )
     assert base != diff_scenario
@@ -56,6 +59,7 @@ def test_carries_scenario_account_mapping_and_exports():
         scenario=_scenario_desc("ec2-small"),
         scenario_id="ec2-small",
         concurrency_mode=ConcurrencyMode.MUTATING,
+        regions=["us-east-1"],
         account_mapping={"PRIMARY": "123456789012"},
         exports={"PRIMARY": {"BucketName": "my-bucket"}},
     )
@@ -71,6 +75,7 @@ def test_exports_defaults_to_empty():
         scenario=_scenario_desc("ec2-small"),
         scenario_id="ec2-small",
         concurrency_mode=ConcurrencyMode.MUTATING,
+        regions=["us-east-1"],
         account_mapping={"PRIMARY": "123456789012"},
     )
     assert cfg.exports == {}
@@ -91,6 +96,7 @@ def test_exports_is_excluded_from_serialization():
         scenario=_scenario_desc("ec2-small"),
         scenario_id="ec2-small",
         concurrency_mode=ConcurrencyMode.MUTATING,
+        regions=["us-east-1"],
         account_mapping={"PRIMARY": "123456789012"},
         exports={"PRIMARY": {"SecretishExport": "s3cr3t-value"}},
     )
@@ -113,6 +119,7 @@ def test_scenario_and_account_ride_inherited_eq_but_exports_do_not():
         scenario=_scenario_desc("ec2-small"),
         scenario_id="ec2-small",
         concurrency_mode=ConcurrencyMode.MUTATING,
+        regions=["us-east-1"],
         account_mapping={"PRIMARY": "111111111111"},
         exports={"PRIMARY": {"K": "v1"}},
     )
@@ -121,6 +128,7 @@ def test_scenario_and_account_ride_inherited_eq_but_exports_do_not():
         scenario=_scenario_desc("ec2-small"),
         scenario_id="ec2-small",
         concurrency_mode=ConcurrencyMode.MUTATING,
+        regions=["us-east-1"],
         account_mapping={"PRIMARY": "111111111111"},
         exports={"PRIMARY": {"K": "v1"}},
     )
@@ -129,6 +137,7 @@ def test_scenario_and_account_ride_inherited_eq_but_exports_do_not():
         scenario=_scenario_desc("ec2-small"),
         scenario_id="ec2-small",
         concurrency_mode=ConcurrencyMode.MUTATING,
+        regions=["us-east-1"],
         account_mapping={"PRIMARY": "222222222222"},
         exports={"PRIMARY": {"K": "v1"}},
     )
@@ -137,6 +146,7 @@ def test_scenario_and_account_ride_inherited_eq_but_exports_do_not():
         scenario=_scenario_desc("ec2-small"),
         scenario_id="ec2-small",
         concurrency_mode=ConcurrencyMode.MUTATING,
+        regions=["us-east-1"],
         account_mapping={"PRIMARY": "111111111111"},
         exports={"PRIMARY": {"K": "v2"}},
     )


### PR DESCRIPTION
## What

Registers confirm-gone delete handlers for `AWS::MediaLive::Channel`, `::Input` and
`::InputSecurityGroup`, and pins the agent's `AWS_REGION` to the scenario's first declared region.

## Why

A scheduled-runner run reported `AWS::MediaLive::Input` and `::InputSecurityGroup` as leaked. Two
causes, one shape:

- `::Input` and `::Channel` were detected by the scan but had no delete path at all. Both are CFN
  `NON_PROVISIONABLE`, so CCAPI refuses them, and no custom handler existed — a permanent leak.
- `::InputSecurityGroup` had a handler, but its single-shot delete always lost with "still being
  used by inputs" — the blockers being exactly the inputs above.

Reset detected all three and still failed, so this was a remediation gap, not a detection gap.

Separately, agent adapters set `AWS_REGION` for Bedrock inference, and the agent's calls against the
test account inherited it — aimed at a region the scenario never declared and the region-restriction
SCP denies.

## How

All three types share one delete engine. The custom-delete wave is unordered, so each handler
deletes its own blockers rather than depending on another running first.

The engine re-describes before every action, so channel state and the blocker set are re-derived per
poll instead of read once at entry. A resource observed `UPDATING` can be `RUNNING` seconds later,
and a single throttled read must not leave a handler believing there is nothing to unblock. One
monotonic deadline is threaded through every nested channel and input delete, following
`handlers/ipam.py`, so a group draining N inputs is bounded by one budget instead of N. Permanent
faults (400/403/422) fail fast; transient ones (409/429/5xx) are retried, and each distinct error
code is logged once so a long retry is visible without spamming.

No prepare handler is registered: the registry chains prepare into delete, so one would only repeat
the loop's own blocker-clearing on a second budget.

For the region fix, `regions[0]` is set in the agent's `cred_env`, which merges over the adapter env.
AGENT-only, since scripts and verifiers declare their own regions in `task.toml [*.env]`.

### Live semantics this encodes, measured on a real account

- Deletes are tombstoned. `delete_*` returns 200 on an already-`DELETED` id and `describe_*` serves
  deleted resources forever, so `State == "DELETED"` is the only gone-signal and `NotFoundException`
  means never-existed. Every delete is therefore safe to re-issue.
- A channel must reach `DELETED` to release its input, and `ListChannels` drops a still-`DELETING`
  channel that is still pinning one, so List-based gone-checks are invalid.
- `DETACHED` inputs still block `DeleteInputSecurityGroup`, and the group deletes while its inputs
  are merely `DELETING`.
- `ConflictException` is unmodeled for `DeleteInputSecurityGroup` but returned anyway, so error codes
  are matched as strings.

## Test plan

- 49 new handler tests at 100% coverage of `handlers/medialive.py`, driving the real unordered
  `ResourceCleaner` pool on a virtual clock.
- Four mutations covering the contract's load-bearing branches (unreadable state read as gone, a
  narrowed stop-state set, one-shot blocker discovery, per-blocker budgets) are each killed by these
  tests.
- Full local suite green on this branch: `2822 passed`, total coverage `88.98%` (gate 85%).
  `ruff check`, `ruff format --check` and `pyright` all clean.
