### PR TITLE
docs: add Codex + OpenAI models on Bedrock to getting-started guide

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -355,21 +355,49 @@ The bearer token is a long-lived (30-day) service-specific credential for `bedro
 
 ### Running with Bedrock (agent uses Bedrock models)
 
+Amazon Bedrock hosts models from multiple providers. aws-bench supports evaluating agents against any of them using a single bearer token:
+
+| Agent (`-a`) | Provider | Bedrock model IDs (`-m`) |
+|--------------|----------|--------------------------|
+| `claude-code` | Anthropic | `global.anthropic.claude-sonnet-4-6`, `global.anthropic.claude-sonnet-5` |
+| `codex` | OpenAI | `openai.gpt-5.6-sol`, `openai.gpt-5.6-terra`, `openai.gpt-5.6-luna` |
+| `aws-bench-baseline-agent` | Anthropic | `us.anthropic.claude-sonnet-4-6` |
+
 ```bash
 # Generate the bearer token (one-time, valid ~30 days)
 eval $(uv run aws-bench env creds --eval)
+```
 
-# Run — pass the token to the agent container
+#### Claude Code (Anthropic models)
+
+```bash
 uv run aws-bench run \
   --env-name awsbench-env \
   -d <dataset> \
   -a claude-code \
-  -m global.anthropic.claude-sonnet-5 \
-  --ve AWS_BEARER_TOKEN_BEDROCK=$AWS_BEARER_TOKEN_BEDROCK \
+  -m global.anthropic.claude-sonnet-4-6 \
+  --ve "AWS_BEARER_TOKEN_BEDROCK=$AWS_BEARER_TOKEN_BEDROCK" \
   --yes
 ```
 
-Other agents auto-detect Bedrock from the presence of `AWS_BEARER_TOKEN_BEDROCK`.
+#### Codex (OpenAI models on Bedrock)
+
+```bash
+uv run aws-bench run \
+  --env-name awsbench-env \
+  -d <dataset> \
+  -a codex \
+  -m openai.gpt-5.6-terra \
+  --ve "AWS_BEARER_TOKEN_BEDROCK=$AWS_BEARER_TOKEN_BEDROCK" \
+  --yes
+```
+
+The GPT-5.6 model family on Bedrock:
+- `openai.gpt-5.6-sol` — frontier reasoning (best quality, higher latency)
+- `openai.gpt-5.6-terra` — balanced production (recommended starting point)
+- `openai.gpt-5.6-luna` — fast and cost-efficient
+
+Both agents auto-detect Bedrock from the presence of `AWS_BEARER_TOKEN_BEDROCK` in the host environment (set by `eval` above). The `--ve` flag passes the token to the verifier container for the LLM judge.
 
 ### Running without Bedrock (agent uses another provider)
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -359,7 +359,7 @@ Amazon Bedrock hosts models from multiple providers. aws-bench supports evaluati
 
 | Agent (`-a`) | Provider | Bedrock model IDs (`-m`) |
 |--------------|----------|--------------------------|
-| `claude-code` | Anthropic | `global.anthropic.claude-sonnet-4-6`, `global.anthropic.claude-sonnet-5` |
+| `claude-code` | Anthropic | `global.anthropic.claude-sonnet-5`, `global.anthropic.claude-sonnet-4-6` |
 | `codex` | OpenAI | `openai.gpt-5.6-sol`, `openai.gpt-5.6-terra`, `openai.gpt-5.6-luna` |
 | `aws-bench-baseline-agent` | Anthropic | `us.anthropic.claude-sonnet-4-6` |
 
@@ -375,7 +375,7 @@ uv run aws-bench run \
   --env-name awsbench-env \
   -d <dataset> \
   -a claude-code \
-  -m global.anthropic.claude-sonnet-4-6 \
+  -m global.anthropic.claude-sonnet-5 \
   --ve "AWS_BEARER_TOKEN_BEDROCK=$AWS_BEARER_TOKEN_BEDROCK" \
   --yes
 ```


### PR DESCRIPTION
Expand the "Running with Bedrock" section to document both supported agents:

- **Claude Code** with Anthropic models (existing, updated example)
- **Codex** with OpenAI GPT-5.6 models on Bedrock (new)

Adds an agent/model table showing available Bedrock model IDs for each agent, with per-agent command examples.

## Testing

All confirmed working e2e (full init → setup → run cycle):

| Agent | Model | Result |
|-------|-------|--------|
| `claude-code` | `global.anthropic.claude-sonnet-4-6` | ✅ reward 1.0 |
| `codex` | `openai.gpt-5.6-terra` | ✅ reward 1.0 |
| `codex` | `openai.gpt-5.6-sol` | ✅ reward 1.0 |

## Changes

Single file: `docs/getting-started.md` (+32/-4 lines)