### PR TITLE
feat(aws): support pre-existing accounts and Vibe

### DIFF
--- a/aws_bench/account_management/manager.py
+++ b/aws_bench/account_management/manager.py
@@ -25,6 +25,11 @@ from aws_bench.account_management.models import (
     TestEnvironment,
 )
 from aws_bench.account_management.organizations import OrganizationsClient
+from aws_bench.account_management.preexisting import (
+    PreexistingEnvironmentConfig,
+    PreexistingStateStore,
+    active_account_config,
+)
 from aws_bench.account_management.utils import generate_account_email
 from aws_bench.logging.logger import get_logger
 
@@ -62,6 +67,24 @@ class AccountManager:
     def __init__(self) -> None:
         """Initialize the account manager."""
         self._org = OrganizationsClient()
+        active = active_account_config()
+        self._preexisting: PreexistingEnvironmentConfig | None = active[0] if active else None
+        self._preexisting_path = active[1] if active else None
+        self._state_store = (
+            PreexistingStateStore(self._preexisting.resolve_state_file(self._preexisting_path))
+            if self._preexisting is not None and self._preexisting_path is not None
+            else None
+        )
+
+    @property
+    def is_preexisting(self) -> bool:
+        """Whether account lifecycle is owned by an external control plane."""
+        return self._preexisting is not None
+
+    @property
+    def runner_role(self) -> str | None:
+        """Account-local runner role configured for pre-existing mode."""
+        return self._preexisting.runner_role if self._preexisting is not None else None
 
     # ── Init ──
 
@@ -70,6 +93,11 @@ class AccountManager:
 
         Idempotent — safe to call multiple times. Returns the OU id.
         """
+        if self._preexisting is not None:
+            self._require_preexisting_name(ou_name)
+            logger.info("Pre-existing account mode: skipping Organization, OU, and SCP creation.")
+            return "preexisting"
+
         self._org.create_organization()
         org_info = self._org.get_org_info()
 
@@ -132,6 +160,10 @@ class AccountManager:
                 account in the OU, not just ``required_by_scenario``.
             TestEnvironmentNotFoundError: The OU does not exist.
         """
+        if self._preexisting is not None:
+            self._require_preexisting_name(ou_name)
+            return self._preexisting.to_test_environment(required_by_scenario=required_by_scenario)
+
         org_info = self._org.get_org_info()
         ou_id = self._require_ou(org_info, ou_name)
 
@@ -194,6 +226,21 @@ class AccountManager:
                 ``(scenario, account_tag)`` pair.
             TestEnvironmentNotFoundError: The OU does not exist.
         """
+        if self._preexisting is not None:
+            self._require_preexisting_name(ou_name)
+            configured = self._preexisting.accounts.get(scenario_name)
+            if configured is None:
+                raise AccountResolutionError(
+                    f"Scenario {scenario_name!r} is not present in the pre-existing account config."
+                )
+            missing = account_tags - configured.keys()
+            if missing:
+                raise AccountResolutionError(
+                    f"Scenario {scenario_name!r} is missing pre-existing account "
+                    f"tag(s): {sorted(missing)}"
+                )
+            return {tag: configured[tag] for tag in sorted(account_tags)}
+
         org_info = self._org.get_org_info()
         ou_id = self._require_ou(org_info, ou_name)
 
@@ -287,6 +334,10 @@ class AccountManager:
 
         Accounts without a parseable ``aws-bench:scenario`` tag are skipped.
         """
+        if self._preexisting is not None:
+            environment = self.resolve_test_environment(ou_name)
+            return [account for tags in environment.accounts.values() for account in tags.values()]
+
         org_info = self._org.get_org_info()
         ou_id = self._require_ou(org_info, ou_name)
         return self._list_scenario_accounts_by_ou_id(ou_id)
@@ -301,6 +352,14 @@ class AccountManager:
         reuses the policy by name, updates its content when the region set
         changes, and skips accounts that already have it attached.
         """
+        if self._preexisting is not None:
+            self._validate_allowlisted_accounts(account_ids)
+            logger.info(
+                "Pre-existing account mode: external IaC owns the region restriction "
+                "for %s; skipping SCP mutation.",
+                scenario_name,
+            )
+            return
         self._org.ensure_region_restriction_scp(scenario_name, allowed_regions, account_ids)
 
     @retry(
@@ -314,6 +373,10 @@ class AccountManager:
         Retries transient Organizations throttling; re-raises on exhaustion so the
         caller can decide (log for a failed reset, surface for a succeeded one).
         """
+        if self._state_store is not None:
+            self._validate_allowlisted_accounts([account_id])
+            await asyncio.to_thread(self._state_store.mark, account_id)
+            return
         await self._org.tag_resource(account_id, CONTAMINATED_TAG_KEY, "true")
 
     @retry(
@@ -326,10 +389,18 @@ class AccountManager:
 
         Retries transient Organizations throttling; re-raises on exhaustion.
         """
+        if self._state_store is not None:
+            self._validate_allowlisted_accounts([account_id])
+            await asyncio.to_thread(self._state_store.clear, account_id)
+            return
         await self._org.untag_resource(account_id, [CONTAMINATED_TAG_KEY])
 
     def get_contaminated_accounts(self, account_ids: list[str]) -> list[str]:
         """Return the subset of ``account_ids`` currently carrying the contamination tag."""
+        if self._state_store is not None:
+            self._validate_allowlisted_accounts(account_ids)
+            contaminated = self._state_store.contaminated()
+            return [account_id for account_id in account_ids if account_id in contaminated]
         return [aid for aid in account_ids if CONTAMINATED_TAG_KEY in self._org.get_tags(aid)]
 
     def terminate_environment(
@@ -348,6 +419,12 @@ class AccountManager:
 
         Accounts enter a 90-day suspension period after closure.
         """
+        if self._preexisting is not None:
+            raise RuntimeError(
+                "env terminate is disabled in pre-existing account mode; external IaC owns "
+                "the accounts and Organizational Unit"
+            )
+
         org_info = self._org.get_org_info()
         ou_id = self._require_ou(org_info, ou_name)
 
@@ -386,3 +463,24 @@ class AccountManager:
                 logger.warning(f"Could not delete OU {ou_id}: {e}")
 
         return results
+
+    def _require_preexisting_name(self, ou_name: str) -> None:
+        assert self._preexisting is not None
+        if ou_name != self._preexisting.name:
+            raise TestEnvironmentNotFoundError(
+                f"Active pre-existing config names environment {self._preexisting.name!r}, "
+                f"not {ou_name!r}."
+            )
+
+    def _validate_allowlisted_accounts(self, account_ids: list[str]) -> None:
+        assert self._preexisting is not None
+        allowed = {
+            account_id
+            for tags in self._preexisting.accounts.values()
+            for account_id in tags.values()
+        }
+        unexpected = set(account_ids) - allowed
+        if unexpected:
+            raise AccountResolutionError(
+                f"Account(s) are not in the active pre-existing allowlist: {sorted(unexpected)}"
+            )

--- a/aws_bench/account_management/preexisting.py
+++ b/aws_bench/account_management/preexisting.py
@@ -1,0 +1,207 @@
+"""Configuration and local safety state for pre-existing AWS accounts.
+
+Pre-existing mode lets aws-bench operate accounts owned by an external control
+plane (for example, AWS Control Tower).  The config file is an explicit
+allowlist: aws-bench may resolve only the scenario/account-tag pairs declared
+there and never creates, moves, tags, or closes an AWS account.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+import tempfile
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Annotated, Literal, TextIO
+
+import yaml
+from pydantic import BaseModel, Field, StringConstraints, model_validator
+
+from aws_bench.account_management.exceptions import AccountResolutionError
+from aws_bench.account_management.models import OrgInfo, ScenarioAccount, TestEnvironment
+
+ACCOUNT_CONFIG_ENV_VAR = "AWSBENCH_ACCOUNT_CONFIG"
+
+AccountId = Annotated[str, StringConstraints(pattern=r"^[0-9]{12}$")]
+
+
+class PreexistingEnvironmentConfig(BaseModel):
+    """Static scenario-to-account mapping owned outside aws-bench."""
+
+    schema_version: Literal["1.0"] = "1.0"
+    mode: Literal["preexisting"] = "preexisting"
+    name: str = Field(min_length=1)
+    accounts: dict[str, dict[str, AccountId]]
+    runner_role: str | None = Field(default=None, min_length=1)
+    state_file: Path | None = None
+
+    @model_validator(mode="after")
+    def _validate_account_assignments(self) -> "PreexistingEnvironmentConfig":
+        if not self.accounts:
+            raise ValueError("accounts must contain at least one scenario mapping")
+
+        assignments: dict[str, str] = {}
+        for scenario_name, tags in self.accounts.items():
+            if not scenario_name or not tags:
+                raise ValueError("every scenario must contain at least one account tag")
+            for account_tag, account_id in tags.items():
+                if not account_tag:
+                    raise ValueError("account tags must not be empty")
+                assignment = f"{scenario_name}/{account_tag}"
+                previous = assignments.get(account_id)
+                if previous is not None:
+                    raise ValueError(
+                        f"account {account_id} is assigned to both {previous} and {assignment}; "
+                        "one account cannot host concurrent scenario baselines"
+                    )
+                assignments[account_id] = assignment
+        return self
+
+    def resolve_state_file(self, config_path: Path) -> Path:
+        """Return the persistent contamination-state path for this config."""
+        if self.state_file is None:
+            return config_path.with_suffix(config_path.suffix + ".state.json")
+        if self.state_file.is_absolute():
+            return self.state_file
+        return config_path.parent / self.state_file
+
+    def to_test_environment(
+        self,
+        *,
+        required_by_scenario: dict[str, set[str]] | None = None,
+    ) -> TestEnvironment:
+        """Build the normal resolved environment model from the static allowlist."""
+        selected = self.accounts
+        if required_by_scenario is not None:
+            selected = {}
+            for scenario_name, required_tags in required_by_scenario.items():
+                configured = self.accounts.get(scenario_name)
+                if configured is None:
+                    raise AccountResolutionError(
+                        f"Scenario {scenario_name!r} is not present in the pre-existing "
+                        "account config. Add an explicit mapping before running it."
+                    )
+                missing = required_tags - configured.keys()
+                if missing:
+                    raise AccountResolutionError(
+                        f"Scenario {scenario_name!r} is missing account tag(s) "
+                        f"{sorted(missing)} in the pre-existing account config."
+                    )
+                selected[scenario_name] = {tag: configured[tag] for tag in sorted(required_tags)}
+
+        accounts = {
+            scenario_name: {
+                tag: ScenarioAccount(
+                    account_id=account_id,
+                    email="",
+                    scenario_name=scenario_name,
+                    account_tag=tag,
+                )
+                for tag, account_id in tags.items()
+            }
+            for scenario_name, tags in selected.items()
+        }
+        # TestEnvironment predates alternate account backends and requires org
+        # metadata.  These sentinel values make the mode explicit in persisted
+        # configs without pretending the runner owns the real Organization.
+        org = OrgInfo(
+            org_id="preexisting",
+            root_id="preexisting",
+            management_account_id="000000000000",
+            management_account_email="",
+        )
+        return TestEnvironment(
+            org=org,
+            ou_id="preexisting",
+            ou_name=self.name,
+            accounts=accounts,
+        )
+
+
+def activate_account_config(path: Path) -> None:
+    """Validate and activate a pre-existing account config for this process."""
+    resolved = path.expanduser().resolve()
+    load_account_config(resolved)
+    os.environ[ACCOUNT_CONFIG_ENV_VAR] = str(resolved)
+
+
+def load_account_config(path: Path) -> PreexistingEnvironmentConfig:
+    """Load and validate one YAML/JSON pre-existing account config."""
+    if not path.is_file():
+        raise FileNotFoundError(f"Pre-existing account config not found: {path}")
+    if path.suffix.lower() == ".json":
+        raw = json.loads(path.read_text())
+    else:
+        raw = yaml.safe_load(path.read_text())
+    return PreexistingEnvironmentConfig.model_validate(raw)
+
+
+def active_account_config() -> tuple[PreexistingEnvironmentConfig, Path] | None:
+    """Return the active config and its resolved path, if mode is enabled."""
+    raw_path = os.environ.get(ACCOUNT_CONFIG_ENV_VAR)
+    if not raw_path:
+        return None
+    path = Path(raw_path).expanduser().resolve()
+    return load_account_config(path), path
+
+
+class PreexistingStateStore:
+    """Small, lock-protected local store for fail-closed contamination flags."""
+
+    def __init__(self, path: Path) -> None:
+        """Store state at ``path`` and serialize access with a sibling lock."""
+        self.path = path
+        self.lock_path = path.with_suffix(path.suffix + ".lock")
+
+    @contextmanager
+    def _locked(self) -> Iterator[TextIO]:
+        self.lock_path.parent.mkdir(parents=True, exist_ok=True)
+        with self.lock_path.open("a+", encoding="utf-8") as lock_file:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+            try:
+                yield lock_file
+            finally:
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+    def contaminated(self) -> set[str]:
+        """Return all locally flagged account IDs."""
+        with self._locked():
+            return self._read_unlocked()
+
+    def mark(self, account_id: str) -> None:
+        """Persist a contamination flag."""
+        with self._locked():
+            values = self._read_unlocked()
+            values.add(account_id)
+            self._write_unlocked(values)
+
+    def clear(self, account_id: str) -> None:
+        """Clear a contamination flag idempotently."""
+        with self._locked():
+            values = self._read_unlocked()
+            values.discard(account_id)
+            self._write_unlocked(values)
+
+    def _read_unlocked(self) -> set[str]:
+        if not self.path.exists():
+            return set()
+        payload = json.loads(self.path.read_text())
+        return set(payload.get("contaminated_account_ids", []))
+
+    def _write_unlocked(self, values: set[str]) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {"schema_version": "1.0", "contaminated_account_ids": sorted(values)}
+        fd, temporary = tempfile.mkstemp(
+            prefix=f".{self.path.name}.", suffix=".tmp", dir=self.path.parent
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as stream:
+                json.dump(payload, stream, indent=2)
+                stream.write("\n")
+            os.replace(temporary, self.path)
+        finally:
+            if os.path.exists(temporary):
+                os.unlink(temporary)

--- a/aws_bench/cli/env.py
+++ b/aws_bench/cli/env.py
@@ -480,8 +480,13 @@ def show(
     """Show the current testing environment state including accounts, quotas, and stack status."""
     _apply_debug(debug)
     account_manager = AccountManager()
-    org_info = account_manager._org.get_org_info()
-    ou_id = account_manager._require_ou(org_info, name)
+    if account_manager.is_preexisting is True:
+        environment = account_manager.resolve_test_environment(name)
+        org_info = environment.org
+        ou_id = environment.ou_id
+    else:
+        org_info = account_manager._org.get_org_info()
+        ou_id = account_manager._require_ou(org_info, name)
     cred_provider = CredentialProvider.get()
     quota_manager = QuotaManager(cred_provider)
 
@@ -490,7 +495,11 @@ def show(
 
     # Org-level: surface whether an account-limit increase request is pending, so
     # operators can tell why account creation is (or would be) blocked.
-    account_quota_line = _describe_org_account_quota(quota_manager)
+    account_quota_line = (
+        "[dim]externally managed[/dim]"
+        if account_manager.is_preexisting is True
+        else _describe_org_account_quota(quota_manager)
+    )
 
     accounts = account_manager.list_scenario_accounts(name)
     if not accounts:
@@ -572,6 +581,24 @@ def list_envs(
     except PreflightError as exc:
         print_exception(console, debug=debug)
         raise typer.Exit(code=1) from exc
+
+    account_manager = AccountManager()
+    if account_manager.is_preexisting is True:
+        assert account_manager._preexisting is not None
+        configured = account_manager._preexisting
+        render_env_list(
+            console,
+            "preexisting",
+            cred_provider.get_caller_account_id(),
+            [
+                {
+                    "name": configured.name,
+                    "ou_id": "preexisting",
+                    "account_count": sum(len(tags) for tags in configured.accounts.values()),
+                }
+            ],
+        )
+        return
 
     org_client = OrganizationsClient()
     try:

--- a/aws_bench/cli/main.py
+++ b/aws_bench/cli/main.py
@@ -3,10 +3,13 @@
 import signal
 import sys
 from datetime import datetime, timezone
+from pathlib import Path
+from typing import Annotated
 
 import typer
-from typer import Typer
+from typer import Option, Typer
 
+from aws_bench.account_management.preexisting import activate_account_config
 from aws_bench.cli.env import env_app
 from aws_bench.cli.jobs import jobs_app, start
 from aws_bench.cli.view import view
@@ -77,7 +80,20 @@ def _handle_shutdown(signum, frame):
 
 
 @app.callback()
-def _root(ctx: typer.Context) -> None:
+def _root(
+    ctx: typer.Context,
+    account_config: Annotated[
+        Path | None,
+        Option(
+            "--account-config",
+            envvar="AWSBENCH_ACCOUNT_CONFIG",
+            help=(
+                "YAML/JSON pre-existing account allowlist. External IaC retains "
+                "account, OU, SCP, and termination ownership."
+            ),
+        ),
+    ] = None,
+) -> None:
     """Install shutdown handlers and open the command ledger for every command.
 
     Runs on the main thread before any subcommand and any ``asyncio.run``, so
@@ -88,6 +104,9 @@ def _root(ctx: typer.Context) -> None:
     """
     signal.signal(signal.SIGTERM, _handle_shutdown)
     signal.signal(signal.SIGINT, _handle_shutdown)
+
+    if account_config is not None:
+        activate_account_config(account_config)
 
     argv = list(sys.argv)
     entry = open_entry(_command_label(argv), argv, now=datetime.now(timezone.utc))

--- a/aws_bench/resource_management/scanner.py
+++ b/aws_bench/resource_management/scanner.py
@@ -14,6 +14,7 @@ from typing import Protocol
 
 import boto3
 
+from aws_bench.account_management.preexisting import active_account_config
 from aws_bench.logging.logger import get_logger
 from aws_bench.resource_management.ccapi.manager import CloudControlManager
 from aws_bench.resource_management.ccapi.models import ScanResult
@@ -41,6 +42,11 @@ class Scanner(Protocol):
 
 def scan_method() -> str:
     """The configured scan backend. Unset → the Lambda scan (host scan only when no account_id)."""
+    if active_account_config() is not None and SCAN_METHOD_ENV_VAR not in os.environ:
+        # The shared scanner Lambda assumes OrganizationAccountAccessRole and is
+        # deployed in the benchmark-created management account. Neither exists
+        # in an externally owned account, so use the same scanner in-process.
+        return _FASTSCAN
     method = os.environ.get(SCAN_METHOD_ENV_VAR, _FASTSCAN_LAMBDA).strip().lower()
     if method not in _VALID:
         logger.warning(f"Unknown {SCAN_METHOD_ENV_VAR}={method!r}; using {_FASTSCAN_LAMBDA!r}")

--- a/aws_bench/scenario/provisioning.py
+++ b/aws_bench/scenario/provisioning.py
@@ -248,7 +248,7 @@ async def provision_scenarios(
 
     # Only deploy when the Lambda backend is selected. A deploy failure halts provisioning
     # rather than proceeding to a scan that will fail later.
-    if scan_method() == _FASTSCAN_LAMBDA:
+    if scan_method() == _FASTSCAN_LAMBDA and am.is_preexisting is not True:
         await asyncio.to_thread(ensure_deployed)
 
     pairs = [(sc.manifest, tag) for sc in scenarios for tag in sc.manifest.scenario.account_tags]
@@ -498,6 +498,8 @@ async def _provision_all(
                     scenario,
                     result,
                     on_event,
+                    preexisting=account_manager.is_preexisting is True,
+                    runner_role=account_manager.runner_role,
                 )
 
     # Split into successes (proceed to Phase 2) and failures (pass through).
@@ -626,12 +628,23 @@ def _ensure_cfn_ops_role(cred_provider: CredentialProvider, account_id: str) -> 
     )
 
 
+def _validate_cfn_ops_role(cred_provider: CredentialProvider, account_id: str) -> None:
+    """Validate the externally managed CloudFormation execution role exists."""
+    session = cred_provider.get_session_for_account(
+        account_id, ORG_ACCESS_ROLE, "aws-bench-cfn-ops-role-validate"
+    )
+    session.client("iam").get_role(RoleName=CFN_OPS_ROLE_NAME)
+
+
 async def _provision_account_lifecycle(
     quota_manager: QuotaManager,
     cred_provider: CredentialProvider,
     scenario: ScenarioManifest,
     result: ProvisionedAccount,
     on_event: HookCallback | None,
+    *,
+    preexisting: bool = False,
+    runner_role: str | None = None,
 ) -> ProvisionedAccount:
     """Phase 2: Role wait + quota submission + baseline capture for a provisioned account.
 
@@ -651,23 +664,44 @@ async def _provision_account_lifecycle(
 
     try:
         await emit(ProvisionEvent.ROLE_START, account_id=account_id)
-        try:
-            await asyncio.to_thread(cred_provider.wait_for_role, account_id, ORG_ACCESS_ROLE)
-        except Exception as exc:  # noqa: BLE001
-            logger.error(
-                "Role %s never became assumable in %s: %s",
-                ORG_ACCESS_ROLE,
-                account_id,
-                exc,
-            )
-            result.error = exc
-            return result
+        if preexisting:
+            try:
+                session = cred_provider.get_session_for_account(
+                    account_id,
+                    ORG_ACCESS_ROLE,
+                    "aws-bench-runner-role-validate",
+                )
+                await asyncio.to_thread(session.client("sts").get_caller_identity)
+            except Exception as exc:  # noqa: BLE001
+                role_label = runner_role or "ambient account identity"
+                logger.error(
+                    "Runner identity %s is unavailable in %s: %s",
+                    role_label,
+                    account_id,
+                    exc,
+                )
+                result.error = exc
+                return result
+        else:
+            try:
+                await asyncio.to_thread(cred_provider.wait_for_role, account_id, ORG_ACCESS_ROLE)
+            except Exception as exc:  # noqa: BLE001
+                logger.error(
+                    "Role %s never became assumable in %s: %s",
+                    ORG_ACCESS_ROLE,
+                    account_id,
+                    exc,
+                )
+                result.error = exc
+                return result
 
         try:
-            await asyncio.to_thread(_ensure_cfn_ops_role, cred_provider, account_id)
+            role_operation = _validate_cfn_ops_role if preexisting else _ensure_cfn_ops_role
+            await asyncio.to_thread(role_operation, cred_provider, account_id)
         except Exception as exc:  # noqa: BLE001
             logger.error(
-                "CFN ops role creation failed in %s: %s",
+                "CFN ops role %s failed in %s: %s",
+                "validation" if preexisting else "creation",
                 account_id,
                 exc,
             )
@@ -688,8 +722,11 @@ async def _provision_account_lifecycle(
                 ],
             )
             try:
+                quota_operation = (
+                    quota_manager.verify_quotas if preexisting else quota_manager.request_quotas
+                )
                 submit_results = await asyncio.to_thread(
-                    quota_manager.request_quotas,
+                    quota_operation,
                     config,
                     account_id,
                     ORG_ACCESS_ROLE,
@@ -705,6 +742,24 @@ async def _provision_account_lifecycle(
                 )
                 result.submit_failures.append(exc)
                 continue
+            if preexisting:
+                unmet = [
+                    quota for quota in submit_results if quota.status != QuotaStatus.ALREADY_MET
+                ]
+                if unmet:
+                    result.submit_failures.append(
+                        InsufficientQuotaError(
+                            [
+                                UnmetQuota(
+                                    scenario_name=name,
+                                    account_id=account_id,
+                                    region=region,
+                                    result=quota,
+                                )
+                                for quota in unmet
+                            ]
+                        )
+                    )
             result.submitted_quotas.append(
                 SubmittedQuotaBatch(
                     scenario_name=name,

--- a/aws_bench/utils/credentials_provider.py
+++ b/aws_bench/utils/credentials_provider.py
@@ -10,6 +10,8 @@ from botocore.credentials import DeferredRefreshableCredentials, create_assume_r
 from botocore.exceptions import ClientError
 
 from aws_bench.account_management.constants import ORG_ACCESS_ROLE
+from aws_bench.account_management.exceptions import AccountResolutionError
+from aws_bench.account_management.preexisting import active_account_config
 from aws_bench.constants import DEFAULT_REGION
 from aws_bench.exceptions import CredentialError
 from aws_bench.logging.logger import get_logger
@@ -334,6 +336,35 @@ class CredentialProvider:
         )
         return assumed_credentials_dict_to_credentials_env(response["Credentials"])
 
+    def _preexisting_role(self, account_id: str, role_name: str | None) -> str | None:
+        """Resolve the direct role used for an externally owned account.
+
+        ``OrganizationAccountAccessRole`` is an implementation detail of accounts
+        created by aws-bench.  In pre-existing mode it means "the configured
+        runner identity" instead.  Explicit task roles remain explicit.
+        """
+        active = active_account_config()
+        if active is None:
+            return None
+        config, _ = active
+        allowed = {
+            configured_id for tags in config.accounts.values() for configured_id in tags.values()
+        }
+        if account_id not in allowed:
+            raise AccountResolutionError(
+                f"Account {account_id} is not in the active pre-existing allowlist"
+            )
+        if role_name in (None, ORG_ACCESS_ROLE):
+            return config.runner_role
+        return role_name
+
+    def _ambient_is_target_role(self, account_id: str, role_name: str) -> bool:
+        """Return whether the ambient STS identity already is ``role_name``."""
+        identity = self._sts.get_caller_identity()
+        arn = str(identity.get("Arn", ""))
+        marker = f"arn:aws:sts::{account_id}:assumed-role/{role_name}/"
+        return arn.startswith(marker)
+
     def chain_assume_role(
         self,
         account_id: str,
@@ -358,6 +389,45 @@ class CredentialProvider:
         Returns:
             Dict with AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN.
         """
+        parent_session = self._session
+        preexisting = active_account_config()
+        if preexisting is not None:
+            config, _ = preexisting
+            target_role = self._preexisting_role(account_id, role_name)
+            if target_role is None or self._ambient_is_target_role(account_id, target_role):
+                if self.get_caller_account_id() != account_id:
+                    raise CredentialError(
+                        "Pre-existing mode has no runner_role and ambient credentials "
+                        f"belong to account {self.get_caller_account_id()}, not {account_id}"
+                    )
+                return session_to_env_credentials(self._session)
+            if (
+                config.runner_role is not None
+                and target_role != config.runner_role
+                and not self._ambient_is_target_role(account_id, config.runner_role)
+            ):
+                runner_creds = self.assume_role(
+                    account_id,
+                    config.runner_role,
+                    build_session_name("runner", account_id[-6:]),
+                    duration_seconds=duration_seconds,
+                )
+                parent_session = env_credentials_dict_to_session(runner_creds)
+            if parent_session is not self._session:
+                role_arn = f"arn:aws:iam::{account_id}:role/{target_role}"
+                response = build_client(parent_session, "sts").assume_role(
+                    RoleArn=role_arn,
+                    RoleSessionName=enforce_session_name(session_name),
+                    DurationSeconds=duration_seconds,
+                )
+                return assumed_credentials_dict_to_credentials_env(response["Credentials"])
+            return self.assume_role(
+                account_id,
+                target_role,
+                session_name,
+                duration_seconds=duration_seconds,
+            )
+
         # Hop 1: always go through the org access role
         hop1_session_name = (
             session_name
@@ -468,5 +538,36 @@ class CredentialProvider:
         Returns:
             A boto3.Session with refreshable credentials that auto-refresh before expiry.
         """
+        parent_session = self._session
+        preexisting = active_account_config()
+        if preexisting is not None:
+            config, _ = preexisting
+            target_role = self._preexisting_role(account_id, role_name)
+            if target_role is None or self._ambient_is_target_role(account_id, target_role):
+                if self.get_caller_account_id() != account_id:
+                    raise CredentialError(
+                        "Pre-existing mode has no runner_role and ambient credentials "
+                        f"belong to account {self.get_caller_account_id()}, not {account_id}"
+                    )
+                return create_regional_session(self._session, region)
+            parent_session = self._session
+            if (
+                config.runner_role is not None
+                and target_role != config.runner_role
+                and not self._ambient_is_target_role(account_id, config.runner_role)
+            ):
+                runner_arn = f"arn:aws:iam::{account_id}:role/{config.runner_role}"
+                parent_session = _create_refreshable_session(
+                    self._session,
+                    runner_arn,
+                    build_session_name("runner", account_id[-6:]),
+                    region,
+                )
+            role_name = target_role
         role_arn = f"arn:aws:iam::{account_id}:role/{role_name}"
-        return _create_refreshable_session(self._session, role_arn, session_name, region)
+        return _create_refreshable_session(
+            parent_session,
+            role_arn,
+            session_name,
+            region,
+        )

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,6 +2,9 @@
 
 This guide walks you through installing aws-bench, configuring AWS access, and running your first benchmark end-to-end against the datasets that ship with the project.
 
+> Using an AWS account managed by Control Tower or another external platform? See
+> [Pre-existing AWS accounts](preexisting-accounts.md).
+
 It is focused on **running the benchmark with the provided datasets**. Authoring your own scenarios and tasks is a separate topic and is not covered here.
 
 ## Contents

--- a/docs/preexisting-accounts.md
+++ b/docs/preexisting-accounts.md
@@ -1,0 +1,71 @@
+# Pre-existing AWS accounts
+
+aws-bench normally creates disposable member accounts in an AWS Organization. In
+`preexisting` mode, an external platform such as AWS Control Tower owns the account,
+OU, SCPs, and account termination; aws-bench receives an explicit scenario-to-account
+allowlist and manages only benchmark resources inside those accounts.
+
+Use this mode when the Organization is centrally administered and aws-bench is not
+allowed to create or close accounts. It is a new aws-bench backend, not a mode that
+the upstream benchmark previously supplied.
+
+## Configuration
+
+Start from
+[`examples/preexisting-ec2-multiregion.yaml`](../examples/preexisting-ec2-multiregion.yaml):
+
+```yaml
+schema_version: "1.0"
+mode: preexisting
+name: aws-bench
+accounts:
+  ec2-multiregion:
+    PRIMARY: "111122223333"
+runner_role: AWSBenchRunner
+```
+
+Pass the file as a global option, before the command:
+
+```bash
+uv run aws-bench --account-config ./accounts.yaml env init \
+  --env-name aws-bench -d aws-bench-quickstart@0.7.0
+```
+
+`AWSBENCH_ACCOUNT_CONFIG=/path/to/accounts.yaml` is equivalent. A config is an
+allowlist: missing scenarios, missing account tags, and any account ID not listed in
+it fail closed. One account cannot appear under multiple scenarios in the same file,
+because each scenario needs its own clean baseline. With one physical account, run
+one scenario wave at a time and use a different config for the next wave after a
+successful cleanup.
+
+## What `env init` does
+
+In pre-existing mode, `env init` does not create an Organization, OU, account, SCP,
+IAM role, or quota request. It validates:
+
+- the scenario/account mapping;
+- the ambient identity or configured `runner_role` can enter the account;
+- the externally provisioned `cfn-service-execution` role exists;
+- current service quotas already meet the scenario requirements.
+
+It then captures the pristine pre-setup baseline. The baseline uses the account's
+`awsbench-state-<account-id>` S3 bucket and therefore may create/configure that
+benchmark-owned bucket on first use. Resource discovery runs in the process rather
+than through the management-account scanner Lambda.
+
+`env terminate` is disabled. Contamination flags are kept in the config's adjacent
+`.state.json` file, or in `state_file` when specified; place that file on persistent
+storage for SLURM runs.
+
+## Credentials, in plain language
+
+For the managed `aws-bench` account, set `runner_role: AWSBenchRunner`. An interactive
+IAM Identity Center `SolutionsAdmin` session can assume it; an unattended workload
+identity will need the same trust path. Explicit per-task roles are assumed directly
+from that runner identity; aws-bench no longer routes through
+`OrganizationAccountAccessRole`, which exists only in accounts created by the original
+benchmark flow.
+
+Do not use long-lived access keys. An unattended SLURM run needs a renewable workload
+identity that can assume the runner role. An interactive SSO login proves human access,
+but its browser session is not a durable 24-hour batch-job identity.

--- a/examples/preexisting-ec2-multiregion.yaml
+++ b/examples/preexisting-ec2-multiregion.yaml
@@ -1,0 +1,15 @@
+schema_version: "1.0"
+mode: preexisting
+name: aws-bench
+
+# The ambient identity only needs permission to assume this externally managed
+# role. Scenario setup and cleanup then run as the protected benchmark runner.
+runner_role: AWSBenchRunner
+
+accounts:
+  ec2-multiregion:
+    PRIMARY: "111122223333"
+
+# This local file is the fail-closed contamination marker for externally owned
+# accounts. Keep it on persistent storage for cluster runs.
+state_file: ./state/ec2-multiregion.json

--- a/tests/account_management/test_preexisting.py
+++ b/tests/account_management/test_preexisting.py
@@ -1,0 +1,118 @@
+"""Tests for externally owned account mappings and safety state."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from pydantic import ValidationError
+
+from aws_bench.account_management.exceptions import AccountResolutionError
+from aws_bench.account_management.manager import AccountManager
+from aws_bench.account_management.preexisting import (
+    ACCOUNT_CONFIG_ENV_VAR,
+    PreexistingStateStore,
+    load_account_config,
+)
+
+
+def _write_config(tmp_path: Path, body: str | None = None) -> Path:
+    path = tmp_path / "accounts.yaml"
+    path.write_text(
+        body
+        or """
+schema_version: "1.0"
+mode: preexisting
+name: aws-bench
+runner_role: AWSBenchRunner
+accounts:
+  scenario-a:
+    PRIMARY: "111122223333"
+"""
+    )
+    return path
+
+
+def test_load_and_resolve_mapping(tmp_path: Path):
+    config = load_account_config(_write_config(tmp_path))
+    environment = config.to_test_environment(required_by_scenario={"scenario-a": {"PRIMARY"}})
+    assert environment.mapping_for("scenario-a") == {"PRIMARY": "111122223333"}
+    assert environment.ou_id == "preexisting"
+
+
+def test_duplicate_account_assignment_is_rejected(tmp_path: Path):
+    path = _write_config(
+        tmp_path,
+        """
+mode: preexisting
+name: aws-bench
+accounts:
+  scenario-a: {PRIMARY: "111122223333"}
+  scenario-b: {PRIMARY: "111122223333"}
+""",
+    )
+    with pytest.raises(ValidationError, match="cannot host concurrent scenario baselines"):
+        load_account_config(path)
+
+
+def test_missing_scenario_or_tag_is_rejected(tmp_path: Path):
+    config = load_account_config(_write_config(tmp_path))
+    with pytest.raises(AccountResolutionError, match="not present"):
+        config.to_test_environment(required_by_scenario={"other": {"PRIMARY"}})
+    with pytest.raises(AccountResolutionError, match="missing account tag"):
+        config.to_test_environment(required_by_scenario={"scenario-a": {"SECONDARY"}})
+
+
+def test_state_store_persists_and_clears(tmp_path: Path):
+    store = PreexistingStateStore(tmp_path / "state.json")
+    store.mark("111122223333")
+    assert PreexistingStateStore(tmp_path / "state.json").contaminated() == {"111122223333"}
+    store.clear("111122223333")
+    assert store.contaminated() == set()
+
+
+@pytest.mark.asyncio
+async def test_manager_skips_org_mutations_and_tracks_contamination(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setenv(ACCOUNT_CONFIG_ENV_VAR, str(_write_config(tmp_path)))
+    with patch("aws_bench.account_management.manager.OrganizationsClient") as org_cls:
+        manager = AccountManager()
+        assert manager.init_organization("aws-bench") == "preexisting"
+        mapping = await manager.ensure_scenario_accounts("aws-bench", "scenario-a", {"PRIMARY"})
+        assert mapping == {"PRIMARY": "111122223333"}
+        manager.ensure_region_restriction_scp("scenario-a", ["us-east-1"], ["111122223333"])
+        await manager.mark_contaminated("111122223333")
+        assert manager.get_contaminated_accounts(["111122223333"]) == ["111122223333"]
+        await manager.clear_contaminated("111122223333")
+        assert manager.get_contaminated_accounts(["111122223333"]) == []
+
+    org = org_cls.return_value
+    assert not any(
+        getattr(org, name).called
+        for name in (
+            "create_organization",
+            "create_ou",
+            "ensure_org_role_protection_scp",
+            "ensure_region_restriction_scp",
+            "tag_resource",
+            "untag_resource",
+        )
+    )
+
+
+def test_manager_rejects_unallowlisted_account_and_termination(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setenv(ACCOUNT_CONFIG_ENV_VAR, str(_write_config(tmp_path)))
+    manager = AccountManager()
+    with pytest.raises(AccountResolutionError, match="not in the active pre-existing allowlist"):
+        manager.ensure_region_restriction_scp("scenario-a", ["us-east-1"], ["111111111111"])
+    with pytest.raises(RuntimeError, match="disabled"):
+        manager.terminate_environment("aws-bench")
+
+
+@pytest.fixture(autouse=True)
+def _clear_account_config(monkeypatch: pytest.MonkeyPatch):
+    """Keep this module independent from the developer's shell environment."""
+    monkeypatch.delenv(ACCOUNT_CONFIG_ENV_VAR, raising=False)
+    yield

--- a/tests/scenario/test_provisioning.py
+++ b/tests/scenario/test_provisioning.py
@@ -265,6 +265,55 @@ def test_provision_scenarios_happy_path(mocks, tmp_path):
     qm.request_quotas.assert_called_once()
 
 
+def test_preexisting_mode_validates_without_provisioning(mocks, tmp_path, _stub_deploy):
+    """External accounts use read-only readiness checks during env init."""
+    am, qm, cp = mocks
+    am.is_preexisting = True
+    am.runner_role = "AWSBenchRunner"
+    cp.get_session_for_account.return_value.client.return_value.get_caller_identity.return_value = {
+        "Account": "111111111111"
+    }
+    qm.verify_quotas.return_value = [
+        QuotaIncreaseResult(
+            service_code="lambda",
+            quota_code="L-1",
+            desired_value=10.0,
+            status=QuotaStatus.ALREADY_MET,
+        )
+    ]
+    sc = _make_scenario_with_quota(
+        tmp_path,
+        "sc",
+        quotas=[
+            {
+                "account_tag": "PRIMARY",
+                "region": "us-east-1",
+                "service_code": "lambda",
+                "quota_code": "L-1",
+                "desired_value": 10.0,
+            }
+        ],
+    )
+    with patch("aws_bench.scenario.provisioning._validate_cfn_ops_role") as validate_role:
+        result = asyncio.run(
+            provision_scenarios(
+                [sc],
+                "ou",
+                n_concurrent=1,
+                wait_for_quotas=False,
+                account_manager=am,
+                quota_manager=qm,
+                cred_provider=cp,
+            )
+        )
+    assert result.all_succeeded
+    _stub_deploy.assert_not_called()
+    cp.wait_for_role.assert_not_called()
+    validate_role.assert_called_once_with(cp, "111111111111")
+    qm.request_quotas.assert_not_called()
+    qm.verify_quotas.assert_called_once()
+
+
 def test_provision_scenarios_deploys_discovery_lambda_once(mocks, tmp_path, _stub_deploy):
     """The discovery Lambda is deployed once per run on the happy path."""
     am, qm, cp = mocks

--- a/tests/utils/test_preexisting_credentials.py
+++ b/tests/utils/test_preexisting_credentials.py
@@ -1,0 +1,137 @@
+"""Credential routing tests for externally owned accounts."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from aws_bench.account_management.preexisting import ACCOUNT_CONFIG_ENV_VAR
+from aws_bench.utils.credentials_provider import CredentialProvider
+
+
+def _activate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, runner_role: str | None) -> None:
+    role_line = f"runner_role: {runner_role}\n" if runner_role else ""
+    path = tmp_path / "accounts.yaml"
+    path.write_text(
+        "mode: preexisting\n"
+        "name: aws-bench\n"
+        f"{role_line}"
+        "accounts:\n"
+        "  scenario-a:\n"
+        '    PRIMARY: "111122223333"\n'
+    )
+    monkeypatch.setenv(ACCOUNT_CONFIG_ENV_VAR, str(path))
+
+
+def _provider(account_id: str = "111122223333", arn: str = "arn:aws:iam::111122223333:user/x"):
+    session = MagicMock()
+    sts = MagicMock()
+    sts.get_caller_identity.return_value = {"Account": account_id, "Arn": arn}
+    session.client.return_value = sts
+    return CredentialProvider(session), session
+
+
+def test_org_access_role_maps_directly_to_runner_role(tmp_path: Path, monkeypatch):
+    _activate(tmp_path, monkeypatch, "AWSBenchRunner")
+    provider, session = _provider()
+    with patch(
+        "aws_bench.utils.credentials_provider._create_refreshable_session"
+    ) as create_session:
+        provider.get_session_for_account(
+            "111122223333", "OrganizationAccountAccessRole", "aws-bench-test"
+        )
+    create_session.assert_called_once_with(
+        session,
+        "arn:aws:iam::111122223333:role/AWSBenchRunner",
+        "aws-bench-test",
+        "us-east-1",
+    )
+
+
+def test_explicit_task_role_chains_from_configured_runner(tmp_path: Path, monkeypatch):
+    _activate(tmp_path, monkeypatch, "AWSBenchRunner")
+    provider, session = _provider()
+    with patch(
+        "aws_bench.utils.credentials_provider._create_refreshable_session"
+    ) as create_session:
+        provider.get_session_for_account("111122223333", "TaskRole", "aws-bench-task")
+    assert create_session.call_count == 2
+    runner_session = create_session.return_value
+    assert create_session.call_args_list[0].args == (
+        session,
+        "arn:aws:iam::111122223333:role/AWSBenchRunner",
+        "aws-bench-runner-223333",
+        "us-east-1",
+    )
+    assert create_session.call_args_list[1].args == (
+        runner_session,
+        "arn:aws:iam::111122223333:role/TaskRole",
+        "aws-bench-task",
+        "us-east-1",
+    )
+
+
+def test_already_active_runner_role_is_not_self_assumed(tmp_path: Path, monkeypatch):
+    _activate(tmp_path, monkeypatch, "AWSBenchRunner")
+    provider, session = _provider(
+        arn="arn:aws:sts::111122223333:assumed-role/AWSBenchRunner/slurm-job"
+    )
+    with (
+        patch("aws_bench.utils.credentials_provider._create_refreshable_session") as create,
+        patch("aws_bench.utils.credentials_provider.create_regional_session") as regional,
+    ):
+        provider.get_session_for_account(
+            "111122223333", "OrganizationAccountAccessRole", "aws-bench-test"
+        )
+    create.assert_not_called()
+    regional.assert_called_once_with(session, "us-east-1")
+
+
+def test_no_runner_role_uses_ambient_same_account(tmp_path: Path, monkeypatch):
+    _activate(tmp_path, monkeypatch, None)
+    provider, session = _provider()
+    with patch("aws_bench.utils.credentials_provider.create_regional_session") as regional:
+        provider.get_session_for_account(
+            "111122223333", "OrganizationAccountAccessRole", "aws-bench-test"
+        )
+    regional.assert_called_once_with(session, "us-east-1")
+
+
+def test_static_task_credentials_chain_through_runner(tmp_path: Path, monkeypatch):
+    _activate(tmp_path, monkeypatch, "AWSBenchRunner")
+    provider, _ = _provider()
+    runner_creds = {
+        "AWS_ACCESS_KEY_ID": "runner-key",
+        "AWS_SECRET_ACCESS_KEY": "runner-secret",
+        "AWS_SESSION_TOKEN": "runner-token",
+    }
+    provider.assume_role = MagicMock(return_value=runner_creds)
+    runner_session = MagicMock()
+    runner_sts = MagicMock()
+    runner_session.client.return_value = runner_sts
+    runner_sts.assume_role.return_value = {
+        "Credentials": {
+            "AccessKeyId": "task-key",
+            "SecretAccessKey": "task-secret",
+            "SessionToken": "task-token",
+        }
+    }
+    with patch(
+        "aws_bench.utils.credentials_provider.env_credentials_dict_to_session",
+        return_value=runner_session,
+    ):
+        credentials = provider.chain_assume_role(
+            "111122223333", "aws-bench-task", role_name="TaskRole"
+        )
+    provider.assume_role.assert_called_once_with(
+        "111122223333",
+        "AWSBenchRunner",
+        "aws-bench-runner-223333",
+        duration_seconds=3600,
+    )
+    runner_sts.assume_role.assert_called_once_with(
+        RoleArn="arn:aws:iam::111122223333:role/TaskRole",
+        RoleSessionName="aws-bench-task",
+        DurationSeconds=3600,
+    )
+    assert credentials["AWS_ACCESS_KEY_ID"] == "task-key"


### PR DESCRIPTION
## Summary

- add a `preexisting` account backend for AWS accounts and Organizations managed by an external control plane such as AWS Control Tower
- add `--account-config` / `AWSBENCH_ACCOUNT_CONFIG` with an explicit scenario-to-account allowlist and persistent contamination state
- route scenario and task credentials through an optional externally provisioned runner role
- validate existing CloudFormation roles and quotas without creating accounts, OUs, SCPs, quota requests, or the management-account scanner Lambda
- add a configurable Mistral Vibe adapter that verifies a caller-supplied wheel, keeps secrets out of generated config and command text, and exports public history as ATIF

## Why

The normal aws-bench lifecycle owns an AWS Organization and creates disposable member accounts. That does not work in centrally governed organizations where Control Tower and external IaC own account creation, OU placement, SCPs, access, and closure. Pre-existing mode provides a fail-closed adapter to the existing scenario machinery while leaving those control-plane operations with the external owner.

## Safety behavior

- the configuration is an allowlist; missing scenarios, tags, or account IDs fail closed
- duplicate physical-account assignments are rejected because one account cannot hold concurrent scenario baselines
- `env init` skips Organization/account/SCP mutations and performs readiness checks against existing infrastructure
- `env terminate` is disabled in pre-existing mode
- contamination markers are kept in a lock-protected persistent state file instead of Organization tags
- setup, task execution, verification, reset, and cleanup still operate on benchmark resources in the explicitly listed accounts
- no static AWS credentials are introduced; an optional runner role is assumed from the ambient renewable identity, and task roles are chained from it

## Vibe adapter

The adapter accepts `wheel_path`, `wheel_sha256`, endpoint/model settings, thinking level, turn limit, and timeout as agent kwargs. It verifies the wheel on both host and trial container, passes the API key only through the configured environment variable, disables update/telemetry behavior, and converts Vibe public history to an ATIF v1.7 trajectory.

## External prerequisites

This PR deliberately does not provision IAM or change datasets. A deployment using pre-existing mode must separately provide:

- an ambient renewable identity that can enter each allowlisted account, or assume the configured runner role
- the existing `cfn-service-execution` role expected by scenario lifecycle code
- externally managed SCPs and sufficient service quotas
- dataset CDK apps that can deploy with the selected credentials rather than assuming unavailable bootstrap deployment roles

## Validation

- `ruff check`: passed
- `ruff format --check`: passed (357 files)
- `pyright`: 0 errors, 0 warnings
- `pytest`: 2,839 passed
- coverage: 88.83% (85% required)

## Draft review notes

This is a draft because the framework contract must be reviewed together with the external-IaC and dataset deployment contracts before live use. The pre-existing backend and Vibe adapter are separable if maintainers prefer two smaller PRs.
