### PR TITLE
fix(reset): fail-closed orphan handling and dependency-ordered VPC teardown

### DIFF
--- a/aws_bench/resource_management/cleanup/handlers/cross_service.py
+++ b/aws_bench/resource_management/cleanup/handlers/cross_service.py
@@ -30,6 +30,7 @@ from aws_bench.resource_management.cleanup.handlers.ipam import (
 )
 from aws_bench.resource_management.cleanup.models import HandlerResult, HandlerStatus, StackResource
 from aws_bench.resource_management.deferred import mark_deferred
+from aws_bench.resource_management.fastscan.listers.custom_listers import default_vpc_ids
 from aws_bench.resource_management.utils.polling import wait_until
 from aws_bench.utils.concurrent import build_client, raise_if_shutdown
 
@@ -51,6 +52,20 @@ _REDSHIFT_POLL_INTERVAL = 15
 # deleted; deletion is async, so wait before the ENI/subnet teardown proceeds.
 _VPCE_DELETE_TIMEOUT = 300
 _VPCE_POLL_INTERVAL = 10
+
+# delete_nat_gateway is async (~1-2 min to reach "deleted"); a NAT gateway holds its
+# EIP association and its own ENI until gone, so it must be awaited before EIP release
+# and before the ENI reap.
+_NAT_GATEWAY_TIMEOUT = 300
+_NAT_GATEWAY_POLL_INTERVAL = 10
+_NAT_GATEWAY_DELETED_STATE = "deleted"
+_NAT_GATEWAY_NOT_FOUND_CODE = "NatGatewayNotFound"
+# EIP alloc/association ids AWS reports as already gone (idempotent release).
+_EIP_ALLOC_GONE_CODES = ("InvalidAllocationID.NotFound", "InvalidAddress.NotFound")
+_EIP_ASSOC_GONE_CODES = ("InvalidAssociationID.NotFound",)
+# IGW faults meaning the detach/delete already effectively happened.
+_IGW_NOT_FOUND_CODE = "InvalidInternetGatewayID.NotFound"
+_IGW_NOT_ATTACHED_CODE = "Gateway.NotAttached"
 
 
 # ── Async delete-and-poll skeleton ───────────────────────────────────
@@ -476,6 +491,319 @@ def _vpc_endpoint_gone(ec2: Any, vpce_id: str) -> bool:
     return not endpoints or all(e.get("State", "").lower() == "deleted" for e in endpoints)
 
 
+# ── NAT gateway / EIP / IGW "mapped public address" wedge ────────────
+#
+# CCAPI's ordered level map omits IGW/NAT/EIP/VPCGatewayAttachment, so it deletes
+# them first with no detach and no dependency ordering. DetachInternetGateway then
+# fails with DependencyViolation "has some mapped public address(es)" because a NAT
+# gateway / EIP is still mapped in the VPC — the IGW (and its VPC) survive forever.
+# This clears the wedge in dependency order: NAT gateways → EIPs → IGW detach+delete.
+
+
+@dataclass
+class VpcPublicAddressWedgeResult:
+    """Outcome of clearing the NAT/EIP/IGW "mapped public address" wedge in some VPCs."""
+
+    nat_deleted: list[str] = field(default_factory=list)
+    eips_released: list[str] = field(default_factory=list)
+    igws_deleted: list[str] = field(default_factory=list)
+    remaining: list[str] = field(default_factory=list)
+    """NAT gateways / EIPs / IGWs that did not clear (delete failed or timed out).
+
+    Non-empty means the wedge is NOT fully cleared; the caller must surface these so
+    the fail-closed reset logic fails rather than absorbing a surviving orphan."""
+
+    @property
+    def cleared_any(self) -> bool:
+        """True if at least one NAT gateway, EIP, or IGW was removed."""
+        return bool(self.nat_deleted or self.eips_released or self.igws_deleted)
+
+
+def clear_vpc_public_address_wedge(
+    session: boto3.Session, vpc_ids: list[str], *, region: str | None = None
+) -> VpcPublicAddressWedgeResult:
+    """Delete NAT gateways, release EIPs, then detach+delete IGWs in ``vpc_ids``.
+
+    Dependency order clears the "mapped public address(es)" DependencyViolation:
+    NAT first (async, awaited to ``deleted`` — it holds an ENI + EIP), then surviving
+    VPC EIPs, then each attached IGW. Idempotent. Anything that fails to clear lands
+    in ``remaining`` rather than being reported as success over a survivor.
+
+    Args:
+        session: Boto3 session scoped to the target account.
+        vpc_ids: VPCs whose NAT/EIP/IGW should be cleared.
+        region: EC2 region; falls back to the session's region.
+
+    Returns:
+        What was removed and what remained (non-empty ``remaining`` = not fully cleared).
+    """
+    vpc_ids = [v for v in vpc_ids if v]
+    result = VpcPublicAddressWedgeResult()
+    if not vpc_ids:
+        return result
+
+    ec2 = build_client(session, "ec2", region_name=region)
+
+    # Phase 1: NAT gateways (hold the EIP association and their own ENI) go first.
+    _clear_nat_gateways(ec2, vpc_ids, result)
+    # Phase 2: release any VPC-scoped EIP the NAT gateway didn't auto-release.
+    _release_vpc_eips(ec2, vpc_ids, result)
+    # Phase 3: detach + delete the now-unblocked IGWs.
+    _clear_internet_gateways(ec2, vpc_ids, result)
+
+    if result.cleared_any or result.remaining:
+        logger.info(
+            f"Public-address wedge for {vpc_ids}: {len(result.nat_deleted)} NAT deleted, "
+            f"{len(result.eips_released)} EIP released, {len(result.igws_deleted)} IGW deleted, "
+            f"{len(result.remaining)} still present"
+        )
+    return result
+
+
+def clear_igw_public_address_wedge(
+    session: boto3.Session, igw_ids: list[str], *, region: str | None = None
+) -> VpcPublicAddressWedgeResult:
+    """Resolve each IGW's attached VPC, then clear the NAT/EIP/IGW wedge for those VPCs.
+
+    Entry point for the ``AWS::EC2::InternetGateway`` pre-delete hook, where the IGW
+    itself (not the VPC) is the flagged resource. Maps ``igw_ids`` to their VPC via
+    ``describe_internet_gateways`` Attachments and delegates to
+    :func:`clear_vpc_public_address_wedge`, which detaches + deletes the IGW once NAT
+    gateways and EIPs are gone. A detached IGW has no VPC wedge (CCAPI can delete it
+    directly), so it resolves to no VPC and is a no-op here.
+    """
+    igw_ids = [i for i in igw_ids if i]
+    if not igw_ids:
+        return VpcPublicAddressWedgeResult()
+    ec2 = build_client(session, "ec2", region_name=region)
+    vpc_ids = _vpcs_for_igws(ec2, igw_ids)
+    # Never detach/delete the account's default-VPC IGW: it is AWS-created, not a leak.
+    try:
+        protected_vpc_ids = default_vpc_ids(ec2)
+    except (ClientError, BotoCoreError) as e:
+        logger.warning(f"DescribeVpcs (is-default) failed; not protecting default VPCs: {e}")
+        protected_vpc_ids = set()
+    vpc_ids = [v for v in vpc_ids if v not in protected_vpc_ids]
+    if not vpc_ids:
+        return VpcPublicAddressWedgeResult()
+    return clear_vpc_public_address_wedge(session, vpc_ids, region=region)
+
+
+def _vpcs_for_igws(ec2: Any, igw_ids: list[str]) -> list[str]:
+    """Return the VPC ids the given IGWs are attached to (deduped; [] on error)."""
+    try:
+        resp = ec2.describe_internet_gateways(InternetGatewayIds=igw_ids)
+    except Exception as e:
+        logger.warning(f"Could not resolve VPCs for IGWs {igw_ids}: {e}")
+        return []
+    vpc_ids: list[str] = []
+    for igw in resp.get("InternetGateways", []):
+        for attachment in igw.get("Attachments", []):
+            vpc_id = attachment.get("VpcId")
+            if vpc_id and vpc_id not in vpc_ids:
+                vpc_ids.append(vpc_id)
+    return vpc_ids
+
+
+def _clear_nat_gateways(ec2: Any, vpc_ids: list[str], result: VpcPublicAddressWedgeResult) -> None:
+    """Delete every non-deleted NAT gateway in ``vpc_ids`` and await terminal ``deleted``."""
+    nat_ids = _describe_nat_gateway_ids(ec2, vpc_ids)
+    if not nat_ids:
+        return
+
+    def _submit(nat_id: str) -> None:
+        try:
+            ec2.delete_nat_gateway(NatGatewayId=nat_id)
+        except ClientError as e:
+            if e.response.get("Error", {}).get("Code", "") == _NAT_GATEWAY_NOT_FOUND_CODE:
+                raise _AlreadyGone from e
+            raise
+
+    unresolved = _submit_and_await(
+        nat_ids,
+        submit=_submit,
+        is_gone=lambda nat_id: _nat_gateway_gone(ec2, nat_id),
+        timeout=_NAT_GATEWAY_TIMEOUT,
+        interval=_NAT_GATEWAY_POLL_INTERVAL,
+        label="NAT gateway",
+        already_gone_exc=_AlreadyGone,
+    )
+    result.nat_deleted.extend(sorted(nat_ids - unresolved))
+    result.remaining.extend(sorted(unresolved))
+
+
+def _describe_nat_gateway_ids(ec2: Any, vpc_ids: list[str]) -> set[str]:
+    """Return ids of NAT gateways in ``vpc_ids`` that are not already deleted/deleting."""
+    try:
+        nat_ids: set[str] = set()
+        for page in ec2.get_paginator("describe_nat_gateways").paginate(
+            Filter=[{"Name": "vpc-id", "Values": vpc_ids}]
+        ):
+            for nat in page.get("NatGateways", []):
+                if nat.get("State") not in ("deleted", "deleting") and nat.get("NatGatewayId"):
+                    nat_ids.add(nat["NatGatewayId"])
+        return nat_ids
+    except Exception as e:
+        logger.warning(f"NAT gateway discovery for {vpc_ids} failed: {e}")
+        return set()
+
+
+def _nat_gateway_gone(ec2: Any, nat_id: str) -> bool:
+    """Whether a NAT gateway is fully ``deleted`` (transient errors -> not yet gone)."""
+    try:
+        resp = ec2.describe_nat_gateways(NatGatewayIds=[nat_id])
+    except ClientError as e:
+        if e.response.get("Error", {}).get("Code", "") == _NAT_GATEWAY_NOT_FOUND_CODE:
+            return True
+        logger.debug(f"Polling NAT gateway '{nat_id}' failed: {e}")
+        return False
+    except Exception as e:
+        logger.debug(f"Polling NAT gateway '{nat_id}' failed: {e}")
+        return False
+    nats = resp.get("NatGateways", [])
+    return not nats or all(n.get("State") == _NAT_GATEWAY_DELETED_STATE for n in nats)
+
+
+def _release_vpc_eips(ec2: Any, vpc_ids: list[str], result: VpcPublicAddressWedgeResult) -> None:
+    """Disassociate (if associated) then release every EIP still mapped into ``vpc_ids``.
+
+    A NAT-gateway-owned EIP is auto-released when the NAT gateway is deleted, so only
+    the addresses that survive Phase 1 are handled here — an EIP still associated to a
+    network interface in a target VPC. Each address that fails to release lands in
+    ``remaining`` so a surviving public address is never reported as cleared.
+    """
+    for addr in _describe_vpc_eips(ec2, vpc_ids):
+        alloc_id = addr.get("AllocationId")
+        if not alloc_id:
+            continue
+        if not _disassociate_eip(ec2, addr):
+            result.remaining.append(alloc_id)
+            continue
+        if _release_eip(ec2, alloc_id):
+            result.eips_released.append(alloc_id)
+        else:
+            result.remaining.append(alloc_id)
+
+
+def _describe_vpc_eips(ec2: Any, vpc_ids: list[str]) -> list[dict]:
+    """Return EIPs mapped to a network interface in ``vpc_ids`` (or [] on error).
+
+    Scoped by the ``network-interface-vpc-id`` filter, which returns only the
+    associated addresses — exactly the "mapped public address(es)" pinning the VPC.
+    An unassociated EIP has no VPC and cannot be attributed to this teardown.
+    """
+    try:
+        return ec2.describe_addresses(
+            Filters=[{"Name": "network-interface-vpc-id", "Values": vpc_ids}]
+        ).get("Addresses", [])
+    except Exception as e:
+        logger.warning(f"EIP discovery for {vpc_ids} failed: {e}")
+        return []
+
+
+def _disassociate_eip(ec2: Any, addr: dict) -> bool:
+    """Disassociate an EIP if it has an association. True if now free (or was already)."""
+    association_id = addr.get("AssociationId")
+    if not association_id:
+        return True
+    try:
+        ec2.disassociate_address(AssociationId=association_id)
+        logger.info(f"Disassociated EIP '{addr.get('AllocationId')}' (assoc {association_id})")
+        return True
+    except ClientError as e:
+        if e.response.get("Error", {}).get("Code", "") in _EIP_ASSOC_GONE_CODES:
+            return True
+        logger.warning(f"Could not disassociate EIP '{addr.get('AllocationId')}': {e}")
+        return False
+    except Exception as e:
+        logger.warning(f"Could not disassociate EIP '{addr.get('AllocationId')}': {e}")
+        return False
+
+
+def _release_eip(ec2: Any, alloc_id: str) -> bool:
+    """Release an EIP by allocation id. True if released or already gone."""
+    try:
+        ec2.release_address(AllocationId=alloc_id)
+        logger.info(f"Released EIP '{alloc_id}'")
+        return True
+    except ClientError as e:
+        if e.response.get("Error", {}).get("Code", "") in _EIP_ALLOC_GONE_CODES:
+            return True
+        logger.warning(f"Could not release EIP '{alloc_id}': {e}")
+        return False
+    except Exception as e:
+        logger.warning(f"Could not release EIP '{alloc_id}': {e}")
+        return False
+
+
+def _clear_internet_gateways(
+    ec2: Any, vpc_ids: list[str], result: VpcPublicAddressWedgeResult
+) -> None:
+    """Detach then delete every IGW attached to ``vpc_ids`` (now unblocked by NAT/EIP)."""
+    for igw_id, attached_vpc in _describe_attached_igws(ec2, vpc_ids):
+        if not _detach_internet_gateway(ec2, igw_id, attached_vpc):
+            result.remaining.append(igw_id)
+            continue
+        if _delete_internet_gateway(ec2, igw_id):
+            result.igws_deleted.append(igw_id)
+        else:
+            result.remaining.append(igw_id)
+
+
+def _describe_attached_igws(ec2: Any, vpc_ids: list[str]) -> list[tuple[str, str]]:
+    """Return (igw_id, vpc_id) for every IGW attached to one of ``vpc_ids`` (or [] on error)."""
+    try:
+        vpc_set = set(vpc_ids)
+        pairs: list[tuple[str, str]] = []
+        for page in ec2.get_paginator("describe_internet_gateways").paginate(
+            Filters=[{"Name": "attachment.vpc-id", "Values": vpc_ids}]
+        ):
+            for igw in page.get("InternetGateways", []):
+                igw_id = igw.get("InternetGatewayId")
+                if not igw_id:
+                    continue
+                for attachment in igw.get("Attachments", []):
+                    if attachment.get("VpcId") in vpc_set:
+                        pairs.append((igw_id, attachment["VpcId"]))
+        return pairs
+    except Exception as e:
+        logger.warning(f"IGW discovery for {vpc_ids} failed: {e}")
+        return []
+
+
+def _detach_internet_gateway(ec2: Any, igw_id: str, vpc_id: str) -> bool:
+    """Detach an IGW from its VPC. True if detached or already detached/gone."""
+    try:
+        ec2.detach_internet_gateway(InternetGatewayId=igw_id, VpcId=vpc_id)
+        logger.info(f"Detached IGW '{igw_id}' from '{vpc_id}'")
+        return True
+    except ClientError as e:
+        code = e.response.get("Error", {}).get("Code", "")
+        if code in (_IGW_NOT_ATTACHED_CODE, _IGW_NOT_FOUND_CODE):
+            return True
+        logger.warning(f"Could not detach IGW '{igw_id}' from '{vpc_id}': {e}")
+        return False
+    except Exception as e:
+        logger.warning(f"Could not detach IGW '{igw_id}' from '{vpc_id}': {e}")
+        return False
+
+
+def _delete_internet_gateway(ec2: Any, igw_id: str) -> bool:
+    """Delete a detached IGW. True if deleted or already gone."""
+    try:
+        ec2.delete_internet_gateway(InternetGatewayId=igw_id)
+        logger.info(f"Deleted IGW '{igw_id}'")
+        return True
+    except ClientError as e:
+        if e.response.get("Error", {}).get("Code", "") == _IGW_NOT_FOUND_CODE:
+            return True
+        logger.warning(f"Could not delete IGW '{igw_id}': {e}")
+        return False
+    except Exception as e:
+        logger.warning(f"Could not delete IGW '{igw_id}': {e}")
+        return False
+
+
 # ── Redshift Serverless ──────────────────────────────────────────────
 
 
@@ -638,6 +966,12 @@ def discover_vpc_dynamic_resources(vpc_ids: list[str], session: boto3.Session) -
     # endpoint (not in the scenario template) pins the subnet (interface ENI) or
     # the VPC (gateway route-table association).
     _delete_vpc_endpoints_in_vpcs(session, vpc_ids)
+
+    # Clear the NAT/EIP/IGW "mapped public address" wedge before the ENI reap: a NAT
+    # gateway holds its own ENI (which would otherwise block the reap) plus its EIP,
+    # and CCAPI's level map omits IGW/NAT/EIP so DetachInternetGateway would fail with
+    # DependencyViolation. Ordered NAT → EIP → IGW clears it; orphans surface below.
+    clear_vpc_public_address_wedge(session, vpc_ids)
 
     # Discover load balancers in these VPCs. An ALB/NLB created out-of-band by an
     # in-cluster controller (e.g. the EKS Auto Mode / AWS Load Balancer Controller

--- a/aws_bench/resource_management/cleanup/handlers/vpc.py
+++ b/aws_bench/resource_management/cleanup/handlers/vpc.py
@@ -4,16 +4,18 @@ Three hooks run before CloudControl (CCAPI) deletes VPC-network resources:
 
 * ``AWS::EC2::VPC`` — discover ENIs, EFS mount targets, and security groups
   attached to the VPC so they are deleted alongside it.
-* ``AWS::EC2::InternetGateway`` — detach the IGW from its VPC(s). CCAPI's
-  ``DeleteResource`` maps to ``DeleteInternetGateway``, which raises
-  ``DependencyViolation`` while the gateway is still attached, so it must be
-  detached first. An IGW attached to the account's **default VPC** is skipped so
-  the default VPC's connectivity is preserved (and it is thus never deleted).
+* ``AWS::EC2::InternetGateway`` — clear the NAT/EIP "mapped public address"
+  wedge, then detach and delete the IGW. CCAPI's ``DeleteResource`` maps to
+  ``DeleteInternetGateway``/``DetachInternetGateway``, which raise
+  ``DependencyViolation`` while a NAT gateway or EIP is still mapped in the VPC,
+  so NAT gateways and EIPs are torn down first (NAT → EIP → IGW). An IGW attached
+  to the account's **default VPC** is skipped so the default VPC's connectivity is
+  preserved (and it is thus never deleted).
 * ``AWS::EC2::VPNGateway`` — the same detach-before-delete requirement, via
   ``DetachVpnGateway`` before ``DeleteVpnGateway``. (No default-VPC guard: AWS
   does not attach a VPN gateway to the default VPC.)
 
-The two detach hooks return no new resources: the gateways are already in the
+The gateway hooks return no new resources: the gateways are already in the
 deletion set; the hooks only make them deletable (like emptying a bucket before
 deleting it). They run only in the CCAPI sweep/reset path (``_resolve_hooks`` is
 reached only when ``custom_delete`` or ``ccapi_fallback`` is set), not in the
@@ -30,16 +32,16 @@ from __future__ import annotations
 from typing import Any
 
 import boto3
-from botocore.exceptions import BotoCoreError, ClientError
+from botocore.exceptions import ClientError
 
 from aws_bench.logging.logger import get_logger
 from aws_bench.resource_management.ccapi.models import Resource
 from aws_bench.resource_management.cleanup.handler_registry import pre_delete_hook
 from aws_bench.resource_management.cleanup.handlers.cross_service import (
+    clear_igw_public_address_wedge,
     discover_vpc_dynamic_resources,
 )
 from aws_bench.resource_management.cleanup.models import StackResource
-from aws_bench.resource_management.fastscan.listers.custom_listers import default_vpc_ids
 from aws_bench.utils.concurrent import build_client
 
 logger = get_logger(__name__)
@@ -66,21 +68,18 @@ def _discover_vpc_dynamic_resources(
 
 
 @pre_delete_hook("AWS::EC2::InternetGateway")
-def _detach_internet_gateways(
+def _clear_igw_public_address_wedge(
     resources: list[StackResource], session: boto3.Session
 ) -> list[Resource]:
-    """Detach Internet Gateways from their VPCs so CCAPI can delete them.
+    """Clear the NAT/EIP wedge blocking a flagged IGW, then detach+delete it.
 
-    ``DeleteInternetGateway`` (CCAPI's ``DeleteResource`` target) requires the
-    IGW to be detached from every VPC first, otherwise it raises
-    ``DependencyViolation``. Returns no new resources — the IGWs are already
-    queued for deletion; this hook only makes them deletable.
-
-    An IGW attached to the account's **default VPC** is left untouched: detaching
-    it would break the default VPC's internet connectivity, and the default VPC
-    is a pre-existing account resource, not scenario state. Skipping the detach
-    also leaves that IGW attached, so the subsequent CCAPI delete fails (a
-    no-op), preserving it.
+    CCAPI's level map omits IGW/NAT/EIP, so DeleteInternetGateway/DetachInternetGateway
+    fails with DependencyViolation "mapped public address(es)" while a NAT gateway/EIP is
+    still mapped. Resolving the IGW's VPC and clearing NAT → EIP → IGW here removes the
+    wedge. An IGW on the account's default VPC is skipped (preserving default connectivity).
+    Discovers no new resources (the teardown deletes the IGW itself), so returns []; the
+    teardown is idempotent, so a second pass (e.g. the VPC hook already handled the VPC) is
+    a clean no-op.
     """
     igw_ids = [
         resource.physical_id
@@ -89,49 +88,8 @@ def _detach_internet_gateways(
     ]
     if not igw_ids:
         return []
-    ec2 = build_client(session, "ec2")
-    # Shared with the fast-scan listers; best-effort here — an empty guard set
-    # must not abort the detach (a wedged scenario stack still gets unblocked).
-    try:
-        protected_vpc_ids = default_vpc_ids(ec2)
-    except (ClientError, BotoCoreError) as e:
-        logger.warning("DescribeVpcs (is-default) failed; not protecting default-VPC IGWs: %s", e)
-        protected_vpc_ids = set()
-    for igw_id in igw_ids:
-        _detach_one_internet_gateway(ec2, igw_id, protected_vpc_ids)
+    clear_igw_public_address_wedge(session, igw_ids)
     return []
-
-
-def _detach_one_internet_gateway(ec2: Any, igw_id: str, protected_vpc_ids: set[str]) -> None:
-    """Detach a single IGW from every non-default VPC it is attached to (best-effort).
-
-    Attachments to a default VPC are skipped so the default VPC's gateway is
-    neither detached nor deleted.
-    """
-    try:
-        resp = ec2.describe_internet_gateways(InternetGatewayIds=[igw_id])
-    except ClientError as e:
-        if not _is_not_found(e):
-            logger.warning("DescribeInternetGateways failed for %s: %s", igw_id, e)
-        return
-    for igw in resp.get("InternetGateways", []):
-        for attachment in igw.get("Attachments", []):
-            vpc_id = attachment.get("VpcId")
-            if not vpc_id or attachment.get("State") not in _ATTACHED_STATES:
-                continue
-            if vpc_id in protected_vpc_ids:
-                logger.debug(
-                    "Skipping detach of IGW %s from default VPC %s (preserving default VPC)",
-                    igw_id,
-                    vpc_id,
-                )
-                continue
-            try:
-                ec2.detach_internet_gateway(InternetGatewayId=igw_id, VpcId=vpc_id)
-                logger.debug("Detached IGW %s from VPC %s", igw_id, vpc_id)
-            except ClientError as e:
-                if not _is_not_found(e):
-                    logger.warning("DetachInternetGateway %s from %s failed: %s", igw_id, vpc_id, e)
 
 
 @pre_delete_hook("AWS::EC2::VPNGateway")

--- a/aws_bench/resource_management/cleanup/manager.py
+++ b/aws_bench/resource_management/cleanup/manager.py
@@ -304,15 +304,27 @@ class CleanupManager:
             succeeded = [stack_name] if result.status == StackDeletionStatus.SUCCESS else []
             failed = [stack_name] if result.status == StackDeletionStatus.FAILED else []
 
+            # This path runs no orphan scan, so a FORCE_DELETE-abandoned resource is
+            # only knowable from the deletion result — surface it here so the caller
+            # (reset) can fail closed instead of absorbing it into a fresh baseline.
+            abandoned = result.abandoned_resources
+            orphaned: dict[str, list[str]] = {}
+            for r in abandoned:
+                orphaned.setdefault(r.resource_type, []).append(r.physical_id or r.logical_id)
+
             region_result = RegionResult(
                 region=region,
                 stacks_found=1,
                 stacks_deleted=len(succeeded),
                 stacks_failed=failed,
-                orphan_count=0,
+                orphan_count=len(abandoned),
             )
 
-            summary = CleanupSummary(regions=[region_result], run_dir=str(run_dir))
+            summary = CleanupSummary(
+                regions=[region_result],
+                orphaned_resources=orphaned,
+                run_dir=str(run_dir),
+            )
             self._log_summary(summary)
             self._save_summary(summary, run_dir)
             return summary

--- a/aws_bench/resource_management/cleanup/models.py
+++ b/aws_bench/resource_management/cleanup/models.py
@@ -152,6 +152,10 @@ class StackDeletionResult:
     status: StackDeletionStatus
     reason: str = ""
     resources: list[StackResource] = field(default_factory=list)
+    # Resources FORCE_DELETE_STACK could not delete and left live in the account.
+    # The single-stack cleanup path runs no orphan scan, so this is the only record
+    # of them and must be surfaced, not dropped.
+    abandoned_resources: list[StackResource] = field(default_factory=list)
     deferred: bool = False
     """The stack did not delete this run, but its only remaining blockers are
     eventually-deletable (subnet/VPC pinned by requester-managed ENIs that AWS

--- a/aws_bench/resource_management/cleanup/stack_deleter.py
+++ b/aws_bench/resource_management/cleanup/stack_deleter.py
@@ -25,6 +25,7 @@ from botocore.exceptions import ClientError
 from aws_bench.exceptions import OperationCancelled
 from aws_bench.logging.logger import get_logger
 from aws_bench.resource_management.cleanup.handlers.cross_service import (
+    clear_vpc_public_address_wedge,
     reap_ipam_child_pools,
     reap_vpc_enis,
     reap_vpc_security_groups,
@@ -648,7 +649,13 @@ class StackDeleter:
     async def _reap_and_retry_networking(
         self, stack_name: str, result: StackDeletionResult
     ) -> None:
-        """Reap leftover VPC ENIs blocking deletion, then retry DeleteStack once."""
+        """Clear the NAT/EIP/IGW wedge and reap blocking ENIs, then retry DeleteStack once.
+
+        The single-stack path runs no pre-delete hooks, so the wedge is otherwise never
+        cleared here. Teardown runs before the ENI reap: a NAT gateway holds its own ENI
+        (awaited to ``deleted``) and EIP, so clearing it first keeps the reap and
+        DetachInternetGateway from tripping on it.
+        """
         if result.status != StackDeletionStatus.FAILED:
             return
         vpc_ids = self._collect_resource_physical_ids(result.resources, "AWS::EC2::VPC")
@@ -656,37 +663,49 @@ class StackDeleter:
             return
 
         logger.debug(
-            "Stack '%s' failed with %d VPC(s); reaping blocking ENIs before retry",
+            "Stack '%s' failed with %d VPC(s); clearing NAT/EIP/IGW wedge and reaping ENIs "
+            "before retry",
             stack_name,
             len(vpc_ids),
         )
-        # Uses the reaper's default 5-min budget — just long enough to force-clear
-        # customer/available ENIs and catch a fast requester-managed release. We no
-        # longer wait out the full 20-40 min for requester-managed ENIs: if only
-        # those remain, the stack is deferred (see _defer_if_requester_eni_only) and
-        # a later run reaps them once the owner releases, rather than idling here.
-        reap = await asyncio.to_thread(
-            reap_vpc_enis,
-            self._session,
-            vpc_ids,
-            region=self._region,
+        # Clear the NAT/EIP/IGW wedge first: a NAT gateway holds its own ENI and EIP, so
+        # tearing it down before the reap keeps DetachInternetGateway from tripping on a
+        # mapped public address. The ENI reap then uses its default 5-min budget — long
+        # enough to force-clear customer/available ENIs and catch a fast requester-managed
+        # release. We no longer wait out the full 20-40 min for requester-managed ENIs: if
+        # only those remain, the stack is deferred (see _defer_if_requester_eni_only) and a
+        # later run reaps them once the owner releases, rather than idling here.
+        wedge = await asyncio.to_thread(
+            clear_vpc_public_address_wedge, self._session, vpc_ids, region=self._region
         )
+        reap = await asyncio.to_thread(reap_vpc_enis, self._session, vpc_ids, region=self._region)
         async with self._manifest_lock:
-            self._manifest.setdefault(stack_name, {})["eni_reap"] = {
+            entry = self._manifest.setdefault(stack_name, {})
+            entry["nat_eip_igw_teardown"] = {
+                "vpc_ids": vpc_ids,
+                "nat_deleted": wedge.nat_deleted,
+                "eips_released": wedge.eips_released,
+                "igws_deleted": wedge.igws_deleted,
+                "remaining": wedge.remaining,
+            }
+            entry["eni_reap"] = {
                 "vpc_ids": vpc_ids,
                 "deleted": reap.deleted,
                 "detached": reap.detached,
                 "remaining": reap.remaining,
             }
-        if not reap.reaped_any and reap.remaining:
-            # Nothing was clearable — only requester-managed ENIs remain. Their
-            # owning service releases them asynchronously (~20-40 min after the
-            # owner's own delete), well past this run's bounded wait, so retrying
-            # DeleteStack now would just stall again. If the stack's only remaining
-            # blockers are the subnet/VPC/SG those ENIs pin, it is eventually-
-            # deletable, not stuck: defer it so the run isn't failed for a state
-            # that self-heals. Otherwise leave it FAILED for force-delete.
-            await self._defer_if_requester_eni_only(stack_name, result, reap.remaining)
+        made_progress = wedge.cleared_any or reap.reaped_any
+        has_orphans = bool(wedge.remaining or reap.remaining)
+        if not made_progress and has_orphans:
+            # Nothing was clearable and something is still outstanding, so a retry would
+            # just stall again. If only requester-managed ENIs remain, the owning service
+            # releases them asynchronously (~20-40 min after the owner's own delete), well
+            # past this run's bounded wait; when the stack's only blockers are the
+            # subnet/VPC/SG those ENIs pin, it is eventually-deletable, not stuck, so defer
+            # it rather than fail the run. An unclearable wedge orphan alone just stalls a
+            # retry, so return without re-driving either way.
+            if reap.remaining:
+                await self._defer_if_requester_eni_only(stack_name, result, reap.remaining)
             return
 
         # ENIs are freed, but a leftover NON-default security group (one a managed

--- a/aws_bench/resource_management/cleanup/stack_deleter.py
+++ b/aws_bench/resource_management/cleanup/stack_deleter.py
@@ -449,12 +449,14 @@ class StackDeleter:
         ``DeleteStack(DeletionMode="FORCE_DELETE_STACK")`` deletes the stack,
         abandoning any resource it cannot delete (with none left, it is a plain
         delete — the "state just lagging" case). On ``DELETE_COMPLETE`` the result
-        flips to SUCCESS; abandoned logical IDs are WARNING-logged and recorded in
-        the manifest (``force_deleted``), then :meth:`_sweep_force_abandoned`
-        best-effort deletes whatever actually survived — so every caller (bulk,
-        single-stack ``cleanup_stack``, reset) reaps the leftovers, not just the
-        bulk path's Phase 3 scan. Never raises: a ``ClientError`` is logged,
-        result left FAILED.
+        flips to SUCCESS; abandoned logical IDs are recorded in the manifest
+        (``force_deleted``), then :meth:`_sweep_force_abandoned` best-effort deletes
+        whatever actually survived — so every caller (bulk, single-stack
+        ``cleanup_stack``, reset) reaps the leftovers, not just the bulk path's
+        Phase 3 scan. Resources the sweep could not delete are surfaced on
+        ``result.abandoned_resources`` so the single-stack/reset path (which runs no
+        orphan scan) can fail closed instead of absorbing them into a fresh baseline.
+        Never raises: a ``ClientError`` is logged, result left FAILED.
 
         ``force_deleted`` keeps its DELETE_FAILED-only contract, but the sweep
         receives the full pre-force snapshot: a resource blocked *behind* a
@@ -501,9 +503,13 @@ class StackDeleter:
             len(abandoned),
             ", ".join(abandoned),
         )
-        await self._sweep_force_abandoned(stack_name, snapshot)
+        # Surface only the survivors the sweep could NOT delete as orphans — the raw
+        # DELETE_FAILED list would false-positive on everything the sweep reaped.
+        result.abandoned_resources = await self._sweep_force_abandoned(stack_name, snapshot)
 
-    async def _sweep_force_abandoned(self, stack_name: str, snapshot: list[StackResource]) -> None:
+    async def _sweep_force_abandoned(
+        self, stack_name: str, snapshot: list[StackResource]
+    ) -> list[StackResource]:
         """Best-effort deletion of resources a ``FORCE_DELETE_STACK`` left behind.
 
         ``snapshot`` is the stack's resource list captured just before the
@@ -522,11 +528,15 @@ class StackDeleter:
         manifest: ``force_abandoned_swept`` (deleted here) and
         ``force_abandoned_sweep_failures`` (still stuck; the next deploy's
         "already exists" failure is then the honest signal).
+
+        Returns the still-stuck survivors so the single-stack/reset caller can
+        surface them as orphans. A best-effort crash returns ``[]`` (never raises),
+        so a sweep that dies under-reports rather than failing the delete.
         """
         try:
             candidates = [r for r in snapshot if r.status != DELETE_COMPLETE]
             if not candidates:
-                return
+                return []
             verified = await self._verifier.verify_resources(candidates)
             by_key = {(r.logical_id, r.physical_id): r for r in candidates}
             survivors = [
@@ -536,7 +546,7 @@ class StackDeleter:
                 and (v.logical_id, v.physical_id) in by_key
             ]
             if not survivors:
-                return
+                return []
             logger.debug(
                 "Stack '%s': sweeping %d resource(s) surviving force-delete: %s",
                 stack_name,
@@ -551,6 +561,7 @@ class StackDeleter:
             )
             failed_ids = {f.identifier for f in failures}
             swept = [r.logical_id for r in survivors if r.physical_id not in failed_ids]
+            stuck = [r for r in survivors if r.physical_id in failed_ids]
             async with self._manifest_lock:
                 entry = self._manifest.setdefault(stack_name, {})
                 if swept:
@@ -564,6 +575,7 @@ class StackDeleter:
                     len(failures),
                     ", ".join(sorted(failed_ids)),
                 )
+            return stuck
         except (asyncio.CancelledError, OperationCancelled):
             raise
         except Exception as e:  # noqa: BLE001 — sweep is best-effort by contract
@@ -572,6 +584,7 @@ class StackDeleter:
                 stack_name,
                 e,
             )
+            return []
 
     def _build_result(
         self, stack_name: str, status: str, resources: list[StackResource]

--- a/aws_bench/resource_management/reset/manager.py
+++ b/aws_bench/resource_management/reset/manager.py
@@ -168,6 +168,7 @@ class ResetManager:
 
         except ResetFailure as e:
             logger.error(f"Reset failed: {e.reason}")
+            orphans = e.details.get("unresolved_orphans") if isinstance(e.details, dict) else None
             return ResetResult(
                 account_id=account_id,
                 scenario_name=env_name,
@@ -175,6 +176,7 @@ class ResetManager:
                 reason=e.reason,
                 details=e.details,
                 suggestion=e.suggestion,
+                unresolved_orphans=orphans,
             )
 
     async def _reset_region(
@@ -241,9 +243,32 @@ class ResetManager:
 
             deleted_stacks = status_deleted + drift_deleted
 
-            # If stacks were deleted, the region is intentionally not at baseline;
-            # the deleted stacks get recreated by setup. Skip final verify.
             if deleted_stacks:
+                # The deleted stacks are intentionally absent (setup recreates them), so they
+                # are exempt from stack-status/drift re-checks — but a resource reset tried and
+                # failed to delete (e.g. an IGW wedged by a mapped EIP), or a baseline type we
+                # can no longer enumerate, must NOT be masked by the stack delete. Re-run only
+                # the new-resource + scan-health census and fail closed if it is not clean.
+                # This runs inside the region's deferred_scope(): the account-global resources
+                # that _delete_new_resources marked deferred are excluded by exclude_deferred,
+                # so the not-yet-deleted globals (deleted later by _delete_global_resources)
+                # never false-positive here.
+                orphan_result = await asyncio.to_thread(
+                    region_verify.find_orphan_resources, region_snapshot
+                )
+                if orphan_result is not None:
+                    raise ResetFailure(
+                        reason=(
+                            f"Stacks deleted for re-setup, but reset left the region "
+                            f"unresolved: {orphan_result.reason}"
+                        ),
+                        details={
+                            "unresolved_orphans": orphan_result.new_resources
+                            or orphan_result.details
+                        },
+                        suggestion=orphan_result.suggestion
+                        or "Run 'aws-bench env cleanup' for full reset",
+                    )
                 return deleted_stacks, global_resources
 
             logger.debug("Phase 4: final verification")
@@ -366,7 +391,8 @@ class ResetManager:
         )
         if failures:
             logger.warning(
-                "Failed to delete %d resource(s); verification will catch it", len(failures)
+                f"Failed to delete {len(failures)} resource(s); the fail-closed verify / "
+                f"orphan re-check will fail the reset if they are still present."
             )
 
     async def _delete_global_resources(

--- a/aws_bench/resource_management/reset/manager.py
+++ b/aws_bench/resource_management/reset/manager.py
@@ -21,7 +21,9 @@ from aws_bench.resource_management.deferred import deferred_scope, mark_deferred
 from aws_bench.resource_management.reset.models import (
     ResetFailure,
     ResetResult,
+    ResetupDeletion,
     RestoreOutcome,
+    StackResetOutcome,
 )
 from aws_bench.resource_management.reset.stack_restorer import StackRestorer
 from aws_bench.resource_management.snapshot.models import Snapshot
@@ -232,23 +234,22 @@ class ResetManager:
             )
             # Delete stacks unrecoverable in place (bad status / undetectable drift)
             # so setup recreates them.
-            status_deleted = await self._delete_unrecoverable_stacks(verify_result, region_restorer)
+            status_outcome = await self._delete_unrecoverable_stacks(verify_result, region_restorer)
             # A DELETE_FAILED stack is in both status_failures and drift_differences;
             # skip the already-deleted ones so restore_stack doesn't error on them.
-            drift_deleted = await self._restore_drifted_stacks(
+            drift_outcome = await self._restore_drifted_stacks(
                 verify_result,
                 region_restorer,
-                already_handled=set(status_deleted),
+                already_handled=set(status_outcome.deleted_stacks),
             )
 
-            deleted_stacks = status_deleted + drift_deleted
+            deleted_stacks = status_outcome.deleted_stacks + drift_outcome.deleted_stacks
 
             if deleted_stacks:
-                # The deleted stacks are intentionally absent (setup recreates them), so they
-                # are exempt from stack-status/drift re-checks — but a resource reset tried and
-                # failed to delete (e.g. an IGW wedged by a mapped EIP), or a baseline type we
-                # can no longer enumerate, must NOT be masked by the stack delete. Re-run only
-                # the new-resource + scan-health census and fail closed if it is not clean.
+                # Deleted stacks are intentionally absent (setup recreates them), so skip the
+                # stack/drift re-checks. But a survivor — reset failed to delete it, an
+                # unenumerable baseline type, or one FORCE_DELETE_STACK abandoned — would be
+                # absorbed into a fresh baseline, so re-run the census and fail closed.
                 # This runs inside the region's deferred_scope(): the account-global resources
                 # that _delete_new_resources marked deferred are excluded by exclude_deferred,
                 # so the not-yet-deleted globals (deleted later by _delete_global_resources)
@@ -256,17 +257,21 @@ class ResetManager:
                 orphan_result = await asyncio.to_thread(
                     region_verify.find_orphan_resources, region_snapshot
                 )
-                if orphan_result is not None:
+                census = self._census_orphans(orphan_result) if orphan_result is not None else {}
+                unresolved = self._merge_orphan_maps(
+                    census, status_outcome.abandoned, drift_outcome.abandoned
+                )
+                if unresolved:
+                    reason = "Stacks deleted for re-setup, but reset left the region unresolved"
+                    if orphan_result is not None:
+                        reason = f"{reason}: {orphan_result.reason}"
+                    else:
+                        n = sum(len(v) for v in unresolved.values())
+                        reason = f"{reason}: {n} resource(s) abandoned by force-delete"
                     raise ResetFailure(
-                        reason=(
-                            f"Stacks deleted for re-setup, but reset left the region "
-                            f"unresolved: {orphan_result.reason}"
-                        ),
-                        details={
-                            "unresolved_orphans": orphan_result.new_resources
-                            or orphan_result.details
-                        },
-                        suggestion=orphan_result.suggestion
+                        reason=reason,
+                        details={"unresolved_orphans": unresolved},
+                        suggestion=(orphan_result.suggestion if orphan_result else None)
                         or "Run 'aws-bench env cleanup' for full reset",
                     )
                 return deleted_stacks, global_resources
@@ -477,9 +482,32 @@ class ResetManager:
                     survivors.setdefault(rtype, []).append(identifier)
         return survivors
 
+    @staticmethod
+    def _merge_orphan_maps(*maps: dict[str, list[dict]] | None) -> dict[str, list[dict]]:
+        """Union several {type: [id-dict, ...]} maps, concatenating ids per type."""
+        merged: dict[str, list[dict]] = {}
+        for m in maps:
+            for rtype, ids in (m or {}).items():
+                merged.setdefault(rtype, []).extend(ids)
+        return merged
+
+    @staticmethod
+    def _census_orphans(result: VerifyResult) -> dict[str, list[dict]]:
+        """Represent a failed orphan census as {type: [id-dict]} for unresolved_orphans.
+
+        A found-new-resource failure carries ``new_resources`` directly; an
+        unenumerable-baseline-type failure carries only type names, so mark each
+        with a sentinel id-dict so the type still surfaces as unresolved.
+        """
+        if result.new_resources:
+            return dict(result.new_resources)
+        details = result.details if isinstance(result.details, dict) else {}
+        unenumerable = details.get("unenumerable_types", [])
+        return {t: [{"error": "could not enumerate"}] for t in unenumerable}
+
     async def _delete_unrecoverable_stacks(
         self, verify_result: VerifyResult, restorer: StackRestorer
-    ) -> list[str]:
+    ) -> StackResetOutcome:
         """Delete stacks unfixable in place so ``env setup`` recreates them.
 
         Covers status mismatches (missing / DELETE_FAILED / ...), drift that regressed to
@@ -516,15 +544,17 @@ class ResetManager:
 
         if not missing and not to_delete:
             logger.debug("Phase 2: No unrecoverable stacks to delete, skipping")
-            return []
+            return StackResetOutcome()
 
         failed_stacks: list[str] = []
         deleted_stacks: list[str] = sorted(missing)
+        abandoned: dict[str, list[dict]] = {}
         for stack_name in to_delete:
             raise_if_shutdown()
-            outcome = await restorer._delete_for_resetup(stack_name)
-            if outcome is RestoreOutcome.DELETED_NEEDS_REDEPLOY:
+            deletion = await restorer._delete_for_resetup(stack_name)
+            if deletion.outcome is RestoreOutcome.DELETED_NEEDS_REDEPLOY:
                 deleted_stacks.append(stack_name)
+                abandoned = self._merge_orphan_maps(abandoned, deletion.abandoned)
                 logger.debug(f"Deleted (will re-setup): {stack_name}")
             else:
                 failed_stacks.append(stack_name)
@@ -538,14 +568,14 @@ class ResetManager:
             )
 
         logger.debug(f"Phase 2: {len(deleted_stacks)} stack(s) will be recreated by setup")
-        return deleted_stacks
+        return StackResetOutcome(deleted_stacks=deleted_stacks, abandoned=abandoned)
 
     async def _restore_drifted_stacks(
         self,
         verify_result: VerifyResult,
         restorer: StackRestorer,
         already_handled: set[str] | None = None,
-    ) -> list[str]:
+    ) -> StackResetOutcome:
         """Restore stacks with drift differences to baseline state.
 
         Args:
@@ -558,16 +588,16 @@ class ResetManager:
                 restoring an already-deleted stack errors.
 
         Returns:
-            Names of stacks that were deleted (revert impossible) and must be
-            recreated by re-running setup. Empty if every stack was reverted
-            in place.
+            A StackResetOutcome naming the stacks that were deleted (revert
+            impossible) and merging any resources their force-delete abandoned.
+            Empty if every stack was reverted in place.
 
         Raises:
             ResetFailure: If any stack could neither be reverted nor deleted.
         """
         if not verify_result.drift_differences:
             logger.debug("Phase 3: No drift differences to fix, skipping")
-            return []
+            return StackResetOutcome()
 
         already_handled = already_handled or set()
         drift_stacks = {
@@ -577,7 +607,7 @@ class ResetManager:
         }
         if not drift_stacks:
             logger.debug("Phase 3: All drifted stacks already handled by status fix, skipping")
-            return []
+            return StackResetOutcome()
 
         logger.debug(f"Phase 3: Fixing drift on {len(drift_stacks)} stack(s)")
 
@@ -585,14 +615,14 @@ class ResetManager:
         # under a small bound to protect the account+region throttle bucket.
         restore_sem = asyncio.Semaphore(_DRIFT_RESTORE_CONCURRENCY)
 
-        async def _restore_one(stack_name: str, baseline: Any) -> tuple[str, RestoreOutcome]:
+        async def _restore_one(stack_name: str, baseline: Any) -> tuple[str, ResetupDeletion]:
             async with restore_sem:
                 raise_if_shutdown()  # don't start a new restore after a shutdown
-                outcome = await restorer.restore_stack(
+                deletion = await restorer.restore_stack(
                     stack_name=stack_name,
                     baseline_drift=baseline,
                 )
-                return stack_name, outcome
+                return stack_name, deletion
 
         outcomes = await asyncio.gather(
             *(_restore_one(name, diff["baseline"]) for name, diff in drift_stacks.items()),
@@ -602,15 +632,17 @@ class ResetManager:
 
         failed_stacks: list[str] = []
         deleted_stacks: list[str] = []
+        abandoned: dict[str, list[dict]] = {}
         for result in outcomes:
             # An unexpected error fails that stack, as the per-stack loop did.
             if isinstance(result, BaseException):
                 raise result
-            stack_name, outcome = result
-            if outcome is RestoreOutcome.RESTORED:
+            stack_name, deletion = result
+            if deletion.outcome is RestoreOutcome.RESTORED:
                 logger.debug(f"Restored: {stack_name}")
-            elif outcome is RestoreOutcome.DELETED_NEEDS_REDEPLOY:
+            elif deletion.outcome is RestoreOutcome.DELETED_NEEDS_REDEPLOY:
                 deleted_stacks.append(stack_name)
+                abandoned = self._merge_orphan_maps(abandoned, deletion.abandoned)
                 logger.debug(f"Deleted (will re-setup): {stack_name}")
             else:
                 failed_stacks.append(stack_name)
@@ -628,7 +660,7 @@ class ResetManager:
             logger.debug(f"Restoring stacks: {len(deleted_stacks)} stack(s) deleted for re-setup")
         else:
             logger.debug("Restoring stacks: all stacks restored successfully")
-        return deleted_stacks
+        return StackResetOutcome(deleted_stacks=deleted_stacks, abandoned=abandoned)
 
     @staticmethod
     async def reset_scenarios(

--- a/aws_bench/resource_management/reset/models.py
+++ b/aws_bench/resource_management/reset/models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum, auto
 from typing import Any
 
@@ -69,3 +69,28 @@ class RestoreOutcome(Enum):
     RESTORED = auto()  # Drift reverted in place; stack matches baseline
     DELETED_NEEDS_REDEPLOY = auto()  # Revert impossible; stack deleted, redeploy via setup
     FAILED = auto()  # Could not restore or delete the stack
+
+
+@dataclass
+class ResetupDeletion:
+    """Outcome of deleting one stack for re-setup, plus resources cleanup abandoned.
+
+    ``abandoned`` maps resource type -> identifier dicts (``{"Identifier": ...}``)
+    that FORCE_DELETE_STACK left live. Reset surfaces these as unresolved
+    orphans so a still-present resource is never absorbed into a fresh baseline.
+    """
+
+    outcome: RestoreOutcome
+    abandoned: dict[str, list[dict]] = field(default_factory=dict)
+
+
+@dataclass
+class StackResetOutcome:
+    """What a stack-remediation phase deleted for re-setup, and what it left behind.
+
+    ``deleted_stacks`` are stacks removed so ``env setup`` recreates them.
+    ``abandoned`` is the merged force-delete orphans across the phase.
+    """
+
+    deleted_stacks: list[str] = field(default_factory=list)
+    abandoned: dict[str, list[dict]] = field(default_factory=dict)

--- a/aws_bench/resource_management/reset/models.py
+++ b/aws_bench/resource_management/reset/models.py
@@ -16,6 +16,10 @@ class ResetResult:
     running the DEPLOY phase after reset completes. ``redeploy_succeeded``
     records the outcome — ``None`` when no redeploy was attempted,
     otherwise the boolean result.
+
+    A non-empty ``unresolved_orphans`` maps a resource type to identifiers that
+    survived reset (or a baseline type it could not enumerate): the account is
+    NOT clean and must never be recaptured as a baseline.
     """
 
     success: bool
@@ -26,6 +30,7 @@ class ResetResult:
     suggestion: str | None = None
     needs_redeploy: bool = False
     redeploy_succeeded: bool | None = None
+    unresolved_orphans: dict[str, list[dict]] | None = None
 
 
 class ResetFailure(Exception):

--- a/aws_bench/resource_management/reset/stack_restorer.py
+++ b/aws_bench/resource_management/reset/stack_restorer.py
@@ -11,7 +11,11 @@ import botocore.exceptions
 
 from aws_bench.logging.logger import get_logger
 from aws_bench.resource_management.cleanup.manager import CleanupManager
-from aws_bench.resource_management.reset.models import ChangesetResult, RestoreOutcome
+from aws_bench.resource_management.reset.models import (
+    ChangesetResult,
+    ResetupDeletion,
+    RestoreOutcome,
+)
 from aws_bench.resource_management.snapshot.drift import DRIFT_CLIENT_CONFIG, DRIFT_DETECTION_FAILED
 from aws_bench.resource_management.utils.cloudformation import (
     get_stack_resource_drifts,
@@ -49,7 +53,7 @@ class StackRestorer:
         self,
         stack_name: str,
         baseline_drift: list[dict[str, Any]],
-    ) -> RestoreOutcome:
+    ) -> ResetupDeletion:
         """Restore stack to baseline drift state.
 
         Strategy:
@@ -63,15 +67,15 @@ class StackRestorer:
             baseline_drift: Expected drift state from snapshot
 
         Returns:
-            RestoreOutcome: RESTORED if reverted in place,
-            DELETED_NEEDS_REDEPLOY if the stack was deleted for re-setup,
-            FAILED if neither could be done.
+            ResetupDeletion: RESTORED with no abandoned resources if reverted in
+            place; otherwise the outcome of the delete-for-re-setup fallback
+            (DELETED_NEEDS_REDEPLOY / FAILED plus any force-abandoned resources).
         """
         logger.debug(f"Attempting to fix drift for stack {stack_name}")
 
         # Attempt 1: Drift revert
         if await self._attempt_drift_revert(stack_name, baseline_drift):
-            return RestoreOutcome.RESTORED
+            return ResetupDeletion(RestoreOutcome.RESTORED)
 
         # Attempt 2: Delete so setup can recreate it
         return await self._delete_for_resetup(stack_name)
@@ -206,7 +210,7 @@ class StackRestorer:
         logger.warning(f"{stack_name}: Changeset not created ({reason}), will delete for re-setup")
         return ChangesetResult.FAILED
 
-    async def _delete_for_resetup(self, stack_name: str) -> RestoreOutcome:
+    async def _delete_for_resetup(self, stack_name: str) -> ResetupDeletion:
         """Delete a stack that couldn't be reverted so setup can recreate it.
 
         The stack is recreated by re-running ``aws-bench env setup`` (the
@@ -218,8 +222,10 @@ class StackRestorer:
             stack_name: Name of stack to delete
 
         Returns:
-            RestoreOutcome.DELETED_NEEDS_REDEPLOY if deletion succeeded,
-            RestoreOutcome.FAILED otherwise.
+            ResetupDeletion carrying DELETED_NEEDS_REDEPLOY on success (with any
+            resources FORCE_DELETE_STACK abandoned, from ``cleanup_stack``'s
+            ``orphaned_resources``) or FAILED otherwise. Already-absent counts as
+            a successful delete with nothing abandoned.
         """
         try:
             logger.debug(f"{stack_name}: Drift revert not possible; deleting for re-setup")
@@ -229,12 +235,16 @@ class StackRestorer:
 
             if not deletion_result.all_stacks_succeeded:
                 logger.error(f"{stack_name}: Deletion failed")
-                return RestoreOutcome.FAILED
+                return ResetupDeletion(RestoreOutcome.FAILED)
 
             logger.debug(
                 f"{stack_name}: Deletion succeeded; will be recreated by 'aws-bench env setup'"
             )
-            return RestoreOutcome.DELETED_NEEDS_REDEPLOY
+            abandoned = {
+                rtype: [{"Identifier": i} for i in ids]
+                for rtype, ids in deletion_result.orphaned_resources.items()
+            }
+            return ResetupDeletion(RestoreOutcome.DELETED_NEEDS_REDEPLOY, abandoned=abandoned)
 
         except ValueError as e:
             # cleanup_stack raises ValueError("... not found in any region") when
@@ -245,13 +255,13 @@ class StackRestorer:
                 logger.debug(
                     f"{stack_name}: Already absent; will be recreated by 'aws-bench env setup'"
                 )
-                return RestoreOutcome.DELETED_NEEDS_REDEPLOY
+                return ResetupDeletion(RestoreOutcome.DELETED_NEEDS_REDEPLOY)
             logger.error(f"{stack_name}: Deletion for re-setup failed: {e}")
-            return RestoreOutcome.FAILED
+            return ResetupDeletion(RestoreOutcome.FAILED)
 
         except Exception as e:
             logger.error(f"{stack_name}: Deletion for re-setup failed: {e}")
-            return RestoreOutcome.FAILED
+            return ResetupDeletion(RestoreOutcome.FAILED)
 
     async def _verify_drift_matches_baseline(
         self, stack_name: str, baseline_drift: list[dict[str, Any]], retries: int = 3

--- a/aws_bench/resource_management/snapshot/manager.py
+++ b/aws_bench/resource_management/snapshot/manager.py
@@ -583,6 +583,23 @@ class SnapshotManager:
             snapshot = self.capture_snapshot_multiregion(
                 scan_session, account_id, ctx.scenario_id, ctx.scenario_hash, ctx.regions
             )
+            # Defense-in-depth: never persist a baseline that still contains a resource
+            # a caller flagged as an unresolved orphan (would hide it forever).
+            if ctx.forbidden_identifiers:
+                present = sorted(
+                    ident
+                    for ids in snapshot.resource_ids.values()
+                    for item in ids
+                    if (ident := item.get("Identifier", "")) in ctx.forbidden_identifiers
+                )
+                if present:
+                    msg = (
+                        f"Refused to save {ctx.stage} baseline for "
+                        f"{ctx.scenario_id}/{account_id}: still contains "
+                        f"{len(present)} flagged orphan(s): {', '.join(present[:5])}"
+                    )
+                    logger.error(msg)
+                    return SnapshotResult(account_id=account_id, success=False, error_message=msg)
             if ctx.output_dir is not None:
                 path = self._write_snapshot_file(ctx.output_dir, ctx.scenario_id, snapshot)
                 logger.debug(

--- a/aws_bench/resource_management/snapshot/models.py
+++ b/aws_bench/resource_management/snapshot/models.py
@@ -115,3 +115,7 @@ class SnapshotContext:
     # When set, the snapshot is written to a JSON file under this directory
     # instead of S3; used by OBSERVABILITY captures.
     output_dir: Path | None = None
+    # Identifiers a caller flagged as unresolved orphans; a captured baseline
+    # containing any of these is refused, never saved (defense-in-depth against
+    # absorbing a live orphan into the baseline).
+    forbidden_identifiers: set[str] = field(default_factory=set)

--- a/aws_bench/resource_management/verify/manager.py
+++ b/aws_bench/resource_management/verify/manager.py
@@ -168,6 +168,23 @@ class VerifyManager:
             f"({len(baseline_types)} resource types from baseline)"
         )
         scan_result = self._scan_mgr.scan_resources(resource_types=list(baseline_types))
+
+        # Fail closed on a persistent scan failure of a baseline-tracked type. The
+        # scanner already retries transient errors internally (8 attempts w/ backoff),
+        # so a type still in scan_result.failed is a non-transient failure.
+        # find_new_resources deliberately SKIPS failed types to avoid false diffs — but
+        # for a type that mattered at setup, silently skipping it would let a leaked
+        # resource in that type hide forever. Scoped to baseline_types only.
+        unenumerable = sorted(t for t in scan_result.failed if t in baseline_types)
+        if unenumerable:
+            logger.warning(f"Could not enumerate baseline resource type(s): {unenumerable}")
+            return VerifyResult(
+                success=False,
+                reason=f"Could not enumerate {len(unenumerable)} baseline resource type(s)",
+                details={"unenumerable_types": unenumerable},
+                suggestion="Run 'aws-bench env cleanup' and 'aws-bench env setup' to reset",
+            )
+
         new_resources = find_new_resources(
             scan_result.detected, baseline_resource_ids, scan_result.failed, baseline_failed
         )
@@ -210,6 +227,19 @@ class VerifyManager:
                 new_resources=new_resources,
             )
         return None
+
+    def find_orphan_resources(self, snapshot: Snapshot) -> VerifyResult | None:
+        """Re-run only the new-resource + scan-health census (no stack/drift checks).
+
+        Reset's fail-closed backstop after deleting stacks for re-setup: a survivor
+        it could not delete or enumerate must fail the reset, not be absorbed into a
+        fresh baseline.
+        """
+        return self._check_new_resources(
+            snapshot.resource_ids,
+            snapshot.failed_resource_types,
+            snapshot.empty_resource_types,
+        )
 
     def _check_stack_status(self, stack_metadata: dict) -> VerifyResult | None:
         """Check CloudFormation stack status.

--- a/aws_bench/scenario/trial.py
+++ b/aws_bench/scenario/trial.py
@@ -551,10 +551,12 @@ class ScenarioTrial:
         elif phase == ScenarioPhase.CLEANUP:
             await self._run_cleanup(script_failed=script_failed)
 
-    async def _run_snapshot(self) -> None:
+    async def _run_snapshot(self, forbidden_identifiers: set[str] | None = None) -> None:
         """Capture the post-setup baseline snapshot for this scenario's accounts.
 
         Assumes a successful deploy; the caller gates on deploy outcome.
+        ``forbidden_identifiers`` are orphan ids the snapshot layer refuses to
+        absorb into a baseline (defense-in-depth for the recapture path).
         """
         ctx = SnapshotContext(
             scenario_id=self._scenario.name,
@@ -562,6 +564,7 @@ class ScenarioTrial:
             regions=self._scenario.manifest.scenario.regions,
             stage=SnapshotStage.POST_SETUP,
             account_ids=list(self._config.account_mapping.values()),
+            forbidden_identifiers=forbidden_identifiers or set(),
         )
 
         results_by_scenario = await ResourceManager.snapshot_scenarios([ctx])
@@ -853,8 +856,18 @@ class ScenarioTrial:
             try:
                 await self._redeploy_with_retry()
 
-                # Recapture baseline snapshot after successful redeploy
-                await self._run_snapshot()
+                # Recapture the baseline only when every account is clean — otherwise a
+                # still-present orphan would be absorbed into the new baseline and hide
+                # forever. The trial fails below on the unclean account, so the run is
+                # discarded and the preserved baseline never goes stale.
+                if self._baseline_recapture_allowed(results):
+                    await self._run_snapshot(self._orphan_identifiers(results))
+                else:
+                    logger.error(
+                        f"Skipping baseline recapture for {self._scenario.name}: an account's "
+                        "reset left unresolved orphans or failed; the prior baseline is "
+                        "preserved to avoid absorbing a live orphan."
+                    )
 
                 # Mark redeploy as successful in results
                 for result in results:
@@ -883,6 +896,26 @@ class ScenarioTrial:
 
         if clear_error is not None:
             raise clear_error
+
+    @staticmethod
+    def _baseline_recapture_allowed(results: list[ResetResult]) -> bool:
+        """A failed or orphan-carrying reset must not refresh the baseline.
+
+        Recapture is scenario-wide, so ANY unclean account would absorb its live
+        orphan into a fresh POST_SETUP baseline (``current - snapshot`` subtracts
+        it forever). When unclean the trial fails and the run is discarded, so the
+        stale baseline is correct to keep.
+        """
+        return all(r.success and not r.unresolved_orphans for r in results)
+
+    @staticmethod
+    def _orphan_identifiers(results: list[ResetResult]) -> set[str]:
+        """Union of identifiers every result flagged as an unresolved orphan."""
+        idents: set[str] = set()
+        for r in results:
+            for ids in (r.unresolved_orphans or {}).values():
+                idents.update(item["Identifier"] for item in ids if "Identifier" in item)
+        return idents
 
     async def _apply_contamination_tags(self, results: list[ResetResult]) -> Exception | None:
         """SET the flag on accounts whose reset failed, CLEAR it on those that succeeded.

--- a/tests/resource_management/cleanup/test_handlers_cross_service.py
+++ b/tests/resource_management/cleanup/test_handlers_cross_service.py
@@ -10,6 +10,7 @@ from botocore.exceptions import ClientError
 from aws_bench.resource_management.cleanup.handlers.cross_service import (
     EniReapResult,
     IpamPoolReapResult,
+    VpcPublicAddressWedgeResult,
     _delete_dms_instances_in_vpcs,
     _delete_eks_resource_group,
     _delete_redshift_resources,
@@ -20,6 +21,8 @@ from aws_bench.resource_management.cleanup.handlers.cross_service import (
     _prepare_security_group,
     cleanup_redshift,
     cleanup_stuck_custom_resource_deps,
+    clear_igw_public_address_wedge,
+    clear_vpc_public_address_wedge,
     delete_dms_instances,
     delete_eks_clusters,
     discover_vpc_dynamic_resources,
@@ -32,6 +35,8 @@ from aws_bench.resource_management.cleanup.handlers.ipam import (
 )
 from aws_bench.resource_management.cleanup.models import StackResource
 from aws_bench.resource_management.deferred import deferred_scope
+
+CROSS = "aws_bench.resource_management.cleanup.handlers.cross_service"
 
 
 def _paginator(pages: list[dict]) -> MagicMock:
@@ -1932,3 +1937,307 @@ def test_reap_ipam_child_pools_shares_one_deadline_across_children():
     # Both children got the SAME non-None deadline -> one shared budget, not two.
     assert deadlines[child_a] is not None
     assert deadlines[child_a] == deadlines[child_b]
+
+
+# -- NAT / EIP / IGW "mapped public address" wedge --
+
+
+def _wedge_ec2(
+    *,
+    nats: list[dict] | None = None,
+    nat_poll_state: str = "deleted",
+    addresses: list[dict] | None = None,
+    igws: list[dict] | None = None,
+) -> tuple[MagicMock, list[str]]:
+    """A mock ec2 client for the wedge teardown plus an ordered destructive-call recorder.
+
+    ``nats``/``igws`` are what the vpc-id-filtered paginators return; ``nat_poll_state``
+    is the State the NAT poll (``describe_nat_gateways``) reports; ``addresses`` is the
+    EIP list ``describe_addresses`` returns.
+    """
+    ec2 = MagicMock()
+    order: list[str] = []
+
+    nat_pag = _paginator([{"NatGateways": nats or []}])
+    igw_pag = _paginator([{"InternetGateways": igws or []}])
+
+    def get_paginator(op: str) -> MagicMock:
+        if op == "describe_nat_gateways":
+            return nat_pag
+        if op == "describe_internet_gateways":
+            return igw_pag
+        raise AssertionError(f"unexpected paginator {op}")
+
+    ec2.get_paginator.side_effect = get_paginator
+    ec2.describe_nat_gateways.return_value = {"NatGateways": [{"State": nat_poll_state}]}
+    ec2.describe_addresses.return_value = {"Addresses": addresses or []}
+
+    for name in (
+        "delete_nat_gateway",
+        "disassociate_address",
+        "release_address",
+        "detach_internet_gateway",
+        "delete_internet_gateway",
+    ):
+        getattr(ec2, name).side_effect = (lambda n: lambda **kw: order.append(n))(name)
+    return ec2, order
+
+
+def test_clear_wedge_deletes_nat_releases_eips_deletes_igw_in_order():
+    """NAT gateway → EIP (disassociate+release / release-only) → IGW detach+delete, in order."""
+    session = MagicMock()
+    ec2, order = _wedge_ec2(
+        nats=[{"NatGatewayId": "nat-1", "State": "available"}],
+        nat_poll_state="deleted",
+        addresses=[
+            {"AllocationId": "eipalloc-1", "AssociationId": "eipassoc-1"},
+            {"AllocationId": "eipalloc-2"},  # no association -> release only
+        ],
+        igws=[{"InternetGatewayId": "igw-1", "Attachments": [{"VpcId": "vpc-1"}]}],
+    )
+    session.client.return_value = ec2
+
+    result = clear_vpc_public_address_wedge(session, ["vpc-1"])
+
+    assert result.nat_deleted == ["nat-1"]
+    assert set(result.eips_released) == {"eipalloc-1", "eipalloc-2"}
+    assert result.igws_deleted == ["igw-1"]
+    assert result.remaining == []
+    assert result.cleared_any is True
+
+    # Only the associated EIP is disassociated; both are released.
+    ec2.disassociate_address.assert_called_once_with(AssociationId="eipassoc-1")
+    assert ec2.release_address.call_count == 2
+    ec2.detach_internet_gateway.assert_called_once_with(InternetGatewayId="igw-1", VpcId="vpc-1")
+    ec2.delete_internet_gateway.assert_called_once_with(InternetGatewayId="igw-1")
+
+    # Dependency order: NAT first, then EIP release, then IGW detach, then IGW delete.
+    assert order.index("delete_nat_gateway") < order.index("release_address")
+    assert order.index("disassociate_address") < order.index("release_address")
+    assert order.index("release_address") < order.index("detach_internet_gateway")
+    assert order.index("detach_internet_gateway") < order.index("delete_internet_gateway")
+
+
+def test_clear_wedge_empty_vpc_is_noop_without_destructive_calls():
+    """A VPC with no NAT/EIP/IGW returns an empty result and makes no destructive calls."""
+    session = MagicMock()
+    ec2, order = _wedge_ec2(nats=[], addresses=[], igws=[])
+    session.client.return_value = ec2
+
+    result = clear_vpc_public_address_wedge(session, ["vpc-1"])
+
+    assert result.cleared_any is False
+    assert result.remaining == []
+    assert order == []
+    ec2.delete_nat_gateway.assert_not_called()
+    ec2.disassociate_address.assert_not_called()
+    ec2.release_address.assert_not_called()
+    ec2.detach_internet_gateway.assert_not_called()
+    ec2.delete_internet_gateway.assert_not_called()
+
+
+def test_clear_wedge_empty_vpc_ids_returns_empty_without_client():
+    session = MagicMock()
+    result = clear_vpc_public_address_wedge(session, ["", None])  # type: ignore[list-item]
+    assert result.cleared_any is False and result.remaining == []
+    session.client.assert_not_called()
+
+
+def test_clear_wedge_nat_never_deleted_lands_in_remaining():
+    """A NAT gateway that never reaches 'deleted' before timeout is reported as remaining."""
+    session = MagicMock()
+    ec2, _order = _wedge_ec2(
+        nats=[{"NatGatewayId": "nat-slow", "State": "available"}],
+        nat_poll_state="deleting",  # never reaches "deleted"
+        addresses=[],
+        igws=[],
+    )
+    session.client.return_value = ec2
+    with patch(f"{CROSS}._NAT_GATEWAY_TIMEOUT", 0), patch(f"{CROSS}.time.sleep"):
+        result = clear_vpc_public_address_wedge(session, ["vpc-1"])
+    assert result.nat_deleted == []
+    assert result.remaining == ["nat-slow"]
+    assert result.cleared_any is False
+
+
+def test_clear_wedge_nat_already_gone_is_treated_as_deleted():
+    """delete_nat_gateway NatGatewayNotFound -> recorded as deleted, not failed."""
+    session = MagicMock()
+    ec2, _order = _wedge_ec2(
+        nats=[{"NatGatewayId": "nat-gone", "State": "available"}], addresses=[], igws=[]
+    )
+    ec2.delete_nat_gateway.side_effect = ClientError(
+        {"Error": {"Code": "NatGatewayNotFound"}}, "DeleteNatGateway"
+    )
+    session.client.return_value = ec2
+    result = clear_vpc_public_address_wedge(session, ["vpc-1"])
+    assert result.nat_deleted == ["nat-gone"]
+    assert result.remaining == []
+
+
+def test_clear_wedge_eip_release_failure_lands_in_remaining():
+    """An EIP that fails to release surfaces in remaining (never a silent success)."""
+    session = MagicMock()
+    ec2, _order = _wedge_ec2(nats=[], addresses=[{"AllocationId": "eipalloc-stuck"}], igws=[])
+    ec2.release_address.side_effect = ClientError(
+        {"Error": {"Code": "AuthFailure"}}, "ReleaseAddress"
+    )
+    session.client.return_value = ec2
+    result = clear_vpc_public_address_wedge(session, ["vpc-1"])
+    assert result.eips_released == []
+    assert result.remaining == ["eipalloc-stuck"]
+
+
+def test_clear_wedge_igw_detach_failure_lands_in_remaining():
+    """An IGW whose detach fails surfaces in remaining and is not deleted."""
+    session = MagicMock()
+    ec2, _order = _wedge_ec2(
+        nats=[],
+        addresses=[],
+        igws=[{"InternetGatewayId": "igw-stuck", "Attachments": [{"VpcId": "vpc-1"}]}],
+    )
+    ec2.detach_internet_gateway.side_effect = ClientError(
+        {"Error": {"Code": "DependencyViolation"}}, "DetachInternetGateway"
+    )
+    session.client.return_value = ec2
+    result = clear_vpc_public_address_wedge(session, ["vpc-1"])
+    assert result.igws_deleted == []
+    assert result.remaining == ["igw-stuck"]
+    ec2.delete_internet_gateway.assert_not_called()
+
+
+def test_clear_wedge_eip_disassociate_failure_lands_in_remaining():
+    """An EIP whose disassociate fails is not released and surfaces in remaining."""
+    session = MagicMock()
+    ec2, _order = _wedge_ec2(
+        nats=[],
+        addresses=[{"AllocationId": "eipalloc-stuck", "AssociationId": "eipassoc-stuck"}],
+        igws=[],
+    )
+    ec2.disassociate_address.side_effect = ClientError(
+        {"Error": {"Code": "AuthFailure"}}, "DisassociateAddress"
+    )
+    session.client.return_value = ec2
+    result = clear_vpc_public_address_wedge(session, ["vpc-1"])
+    assert result.eips_released == []
+    assert result.remaining == ["eipalloc-stuck"]
+    ec2.release_address.assert_not_called()
+
+
+def test_clear_wedge_igw_delete_failure_after_detach_lands_in_remaining():
+    """An IGW that detaches but fails to delete surfaces in remaining, not deleted."""
+    session = MagicMock()
+    ec2, _order = _wedge_ec2(
+        nats=[],
+        addresses=[],
+        igws=[{"InternetGatewayId": "igw-stuck", "Attachments": [{"VpcId": "vpc-1"}]}],
+    )
+    ec2.delete_internet_gateway.side_effect = ClientError(
+        {"Error": {"Code": "DependencyViolation"}}, "DeleteInternetGateway"
+    )
+    session.client.return_value = ec2
+    result = clear_vpc_public_address_wedge(session, ["vpc-1"])
+    assert result.igws_deleted == []
+    assert result.remaining == ["igw-stuck"]
+    ec2.detach_internet_gateway.assert_called_once_with(
+        InternetGatewayId="igw-stuck", VpcId="vpc-1"
+    )
+
+
+def test_clear_wedge_igw_already_detached_and_gone_codes_are_idempotent():
+    """Gateway.NotAttached on detach and NotFound on delete are treated as success."""
+    session = MagicMock()
+    ec2, _order = _wedge_ec2(
+        nats=[],
+        addresses=[],
+        igws=[{"InternetGatewayId": "igw-1", "Attachments": [{"VpcId": "vpc-1"}]}],
+    )
+    ec2.detach_internet_gateway.side_effect = ClientError(
+        {"Error": {"Code": "Gateway.NotAttached"}}, "DetachInternetGateway"
+    )
+    ec2.delete_internet_gateway.side_effect = ClientError(
+        {"Error": {"Code": "InvalidInternetGatewayID.NotFound"}}, "DeleteInternetGateway"
+    )
+    session.client.return_value = ec2
+    result = clear_vpc_public_address_wedge(session, ["vpc-1"])
+    assert result.igws_deleted == ["igw-1"]
+    assert result.remaining == []
+
+
+def test_clear_wedge_discovery_errors_are_swallowed():
+    """A describe failure on each phase is logged and swallowed, not raised."""
+    session = MagicMock()
+    ec2 = MagicMock()
+    ec2.get_paginator.side_effect = Exception("boom")
+    ec2.describe_addresses.side_effect = Exception("boom")
+    session.client.return_value = ec2
+    result = clear_vpc_public_address_wedge(session, ["vpc-1"])
+    assert result.cleared_any is False and result.remaining == []
+
+
+def test_clear_igw_wedge_resolves_vpc_from_attachments_and_delegates():
+    """The IGW entry point resolves the VPC via describe_internet_gateways then delegates."""
+    session = MagicMock()
+    ec2 = MagicMock()
+    ec2.describe_internet_gateways.return_value = {
+        "InternetGateways": [{"InternetGatewayId": "igw-1", "Attachments": [{"VpcId": "vpc-9"}]}]
+    }
+    # default_vpc_ids() iterates a describe_vpcs paginator; stub it empty (no default VPC).
+    ec2.get_paginator.return_value.paginate.return_value = iter([{"Vpcs": []}])
+    session.client.return_value = ec2
+    with patch(f"{CROSS}.clear_vpc_public_address_wedge") as mock_clear:
+        clear_igw_public_address_wedge(session, ["igw-1"])
+    ec2.describe_internet_gateways.assert_called_once_with(InternetGatewayIds=["igw-1"])
+    mock_clear.assert_called_once_with(session, ["vpc-9"], region=None)
+
+
+def test_clear_igw_wedge_detached_igw_is_noop():
+    """A detached IGW (no VPC attachment) resolves to no VPC and does nothing."""
+    session = MagicMock()
+    ec2 = MagicMock()
+    ec2.describe_internet_gateways.return_value = {
+        "InternetGateways": [{"InternetGatewayId": "igw-1", "Attachments": []}]
+    }
+    # default_vpc_ids() iterates a describe_vpcs paginator; stub it empty (no default VPC).
+    ec2.get_paginator.return_value.paginate.return_value = iter([{"Vpcs": []}])
+    session.client.return_value = ec2
+    with patch(f"{CROSS}.clear_vpc_public_address_wedge") as mock_clear:
+        result = clear_igw_public_address_wedge(session, ["igw-1"])
+    mock_clear.assert_not_called()
+    assert result.cleared_any is False
+
+
+def test_clear_igw_wedge_empty_ids_returns_empty_without_client():
+    session = MagicMock()
+    result = clear_igw_public_address_wedge(session, [""])
+    assert result.cleared_any is False
+    session.client.assert_not_called()
+
+
+def test_discover_vpc_dynamic_resources_clears_wedge_before_eni_reap():
+    """The VPC hook clears the NAT/EIP/IGW wedge before the ENI reap.
+
+    A NAT gateway holds its own ENI, so clearing it first means the ENI reap won't
+    trip over it.
+    """
+    session = MagicMock()
+    session.client.return_value = MagicMock()
+    call_order: list[str] = []
+    with (
+        patch(f"{CROSS}._delete_eks_clusters_in_vpcs"),
+        patch(f"{CROSS}._delete_dms_instances_in_vpcs"),
+        patch(f"{CROSS}._delete_vpc_endpoints_in_vpcs"),
+        patch(f"{CROSS}._discover_load_balancers_in_vpcs", return_value=[]),
+        patch(f"{CROSS}._discover_efs_mount_targets", return_value=[]),
+        patch(f"{CROSS}._discover_security_groups", return_value=[]),
+        patch(
+            f"{CROSS}.clear_vpc_public_address_wedge",
+            side_effect=lambda *a, **k: call_order.append("wedge") or VpcPublicAddressWedgeResult(),
+        ),
+        patch(
+            f"{CROSS}.reap_vpc_enis",
+            side_effect=lambda *a, **k: call_order.append("enis") or EniReapResult(),
+        ),
+    ):
+        discover_vpc_dynamic_resources(["vpc-123"], session)
+    assert call_order.index("wedge") < call_order.index("enis")

--- a/tests/resource_management/cleanup/test_handlers_igw.py
+++ b/tests/resource_management/cleanup/test_handlers_igw.py
@@ -1,4 +1,9 @@
-"""Tests for the Internet Gateway / VPN Gateway detach pre-delete hooks."""
+"""Tests for the VPN Gateway detach pre-delete hook.
+
+The Internet Gateway hook now clears the NAT/EIP/IGW "mapped public address" wedge
+(see ``test_handlers_cross_service.py`` and ``test_handlers_vpc.py``); its default-VPC
+skip is covered by the cross-service wedge tests.
+"""
 
 from __future__ import annotations
 
@@ -6,10 +11,7 @@ from unittest.mock import MagicMock
 
 from botocore.exceptions import ClientError
 
-from aws_bench.resource_management.cleanup.handlers.vpc import (
-    _detach_internet_gateways,
-    _detach_vpn_gateways,
-)
+from aws_bench.resource_management.cleanup.handlers.vpc import _detach_vpn_gateways
 from aws_bench.resource_management.cleanup.models import StackResource
 
 
@@ -23,199 +25,6 @@ def _vgw(physical_id: str) -> StackResource:
 
 def _client_error(code: str, op: str) -> ClientError:
     return ClientError({"Error": {"Code": code, "Message": "x"}}, op)
-
-
-def _session_with(ec2: MagicMock, default_vpc_ids: tuple[str, ...] = ()) -> MagicMock:
-    """Wire an ec2 mock into a session and stub the default-VPC lookup.
-
-    The lookup is the shared paginated ``default_vpc_ids`` helper
-    (fastscan ``custom_listers``), so the stub feeds the paginator path.
-    """
-    paginator = MagicMock()
-    paginator.paginate.return_value = iter([{"Vpcs": [{"VpcId": v} for v in default_vpc_ids]}])
-    ec2.get_paginator.return_value = paginator
-    session = MagicMock()
-    session.client.return_value = ec2
-    return session
-
-
-# ---------------------------------------------------------------------------
-# Internet Gateway
-# ---------------------------------------------------------------------------
-
-
-def test_igw_hook_no_matching_resources_returns_empty_without_client():
-    session = MagicMock()
-    result = _detach_internet_gateways(
-        [StackResource("L", "vpc-1", "AWS::EC2::VPC", "CREATE_COMPLETE")], session
-    )
-    assert result == []
-    session.client.assert_not_called()
-
-
-def test_igw_hook_skips_empty_physical_id():
-    session = MagicMock()
-    result = _detach_internet_gateways([_igw("")], session)
-    assert result == []
-    session.client.assert_not_called()
-
-
-def test_igw_hook_detaches_each_attached_vpc():
-    ec2 = MagicMock()
-    ec2.describe_internet_gateways.return_value = {
-        "InternetGateways": [
-            {
-                "InternetGatewayId": "igw-1",
-                "Attachments": [
-                    {"VpcId": "vpc-1", "State": "available"},
-                    {"VpcId": "vpc-2", "State": "available"},
-                ],
-            }
-        ]
-    }
-    session = _session_with(ec2)
-
-    result = _detach_internet_gateways([_igw("igw-1")], session)
-
-    assert result == []
-    ec2.describe_internet_gateways.assert_called_once_with(InternetGatewayIds=["igw-1"])
-    assert ec2.detach_internet_gateway.call_count == 2
-    ec2.detach_internet_gateway.assert_any_call(InternetGatewayId="igw-1", VpcId="vpc-1")
-    ec2.detach_internet_gateway.assert_any_call(InternetGatewayId="igw-1", VpcId="vpc-2")
-
-
-def test_igw_hook_skips_already_detached_attachment():
-    ec2 = MagicMock()
-    ec2.describe_internet_gateways.return_value = {
-        "InternetGateways": [
-            {"InternetGatewayId": "igw-1", "Attachments": [{"VpcId": "vpc-1", "State": "detached"}]}
-        ]
-    }
-    session = _session_with(ec2)
-
-    _detach_internet_gateways([_igw("igw-1")], session)
-
-    ec2.detach_internet_gateway.assert_not_called()
-
-
-def test_igw_hook_skips_default_vpc_attachment():
-    """An IGW attached to a default VPC must not be detached (or deleted)."""
-    ec2 = MagicMock()
-    ec2.describe_internet_gateways.return_value = {
-        "InternetGateways": [
-            {
-                "InternetGatewayId": "igw-1",
-                "Attachments": [{"VpcId": "vpc-def", "State": "available"}],
-            }
-        ]
-    }
-    session = _session_with(ec2, default_vpc_ids=("vpc-def",))
-
-    result = _detach_internet_gateways([_igw("igw-1")], session)
-
-    assert result == []
-    ec2.get_paginator.assert_called_once_with("describe_vpcs")
-    ec2.get_paginator.return_value.paginate.assert_called_once_with(
-        Filters=[{"Name": "is-default", "Values": ["true"]}]
-    )
-    ec2.detach_internet_gateway.assert_not_called()
-
-
-def test_igw_hook_detaches_non_default_but_skips_default():
-    """With a mix, only the non-default VPC attachment is detached."""
-    ec2 = MagicMock()
-    ec2.describe_internet_gateways.side_effect = [
-        {
-            "InternetGateways": [
-                {
-                    "InternetGatewayId": "igw-def",
-                    "Attachments": [{"VpcId": "vpc-def", "State": "available"}],
-                }
-            ]
-        },
-        {
-            "InternetGateways": [
-                {
-                    "InternetGatewayId": "igw-app",
-                    "Attachments": [{"VpcId": "vpc-app", "State": "available"}],
-                }
-            ]
-        },
-    ]
-    session = _session_with(ec2, default_vpc_ids=("vpc-def",))
-
-    result = _detach_internet_gateways([_igw("igw-def"), _igw("igw-app")], session)
-
-    assert result == []
-    ec2.detach_internet_gateway.assert_called_once_with(
-        InternetGatewayId="igw-app", VpcId="vpc-app"
-    )
-
-
-def test_igw_hook_detaches_when_default_vpc_lookup_fails():
-    """If DescribeVpcs fails, fall back to detaching (best-effort, logged).
-
-    The shared ``default_vpc_ids`` helper propagates the error; the hook wraps
-    it fail-open, so the detach still runs with no VPCs protected.
-    """
-    ec2 = MagicMock()
-    ec2.get_paginator.return_value.paginate.side_effect = _client_error(
-        "UnauthorizedOperation", "DescribeVpcs"
-    )
-    ec2.describe_internet_gateways.return_value = {
-        "InternetGateways": [
-            {
-                "InternetGatewayId": "igw-1",
-                "Attachments": [{"VpcId": "vpc-1", "State": "available"}],
-            }
-        ]
-    }
-    session = MagicMock()
-    session.client.return_value = ec2
-
-    result = _detach_internet_gateways([_igw("igw-1")], session)
-
-    assert result == []
-    ec2.detach_internet_gateway.assert_called_once_with(InternetGatewayId="igw-1", VpcId="vpc-1")
-
-
-def test_igw_hook_swallows_not_found_on_describe():
-    ec2 = MagicMock()
-    ec2.describe_internet_gateways.side_effect = _client_error(
-        "InvalidInternetGatewayID.NotFound", "DescribeInternetGateways"
-    )
-    session = _session_with(ec2)
-
-    result = _detach_internet_gateways([_igw("igw-1")], session)
-
-    assert result == []
-    ec2.detach_internet_gateway.assert_not_called()
-
-
-def test_igw_hook_continues_after_a_detach_error():
-    ec2 = MagicMock()
-    ec2.describe_internet_gateways.return_value = {
-        "InternetGateways": [
-            {
-                "InternetGatewayId": "igw-1",
-                "Attachments": [
-                    {"VpcId": "vpc-1", "State": "available"},
-                    {"VpcId": "vpc-2", "State": "available"},
-                ],
-            }
-        ]
-    }
-    ec2.detach_internet_gateway.side_effect = [
-        _client_error("DependencyViolation", "DetachInternetGateway"),
-        None,
-    ]
-    session = _session_with(ec2)
-
-    # Must not raise; both attachments are attempted.
-    result = _detach_internet_gateways([_igw("igw-1")], session)
-
-    assert result == []
-    assert ec2.detach_internet_gateway.call_count == 2
 
 
 # ---------------------------------------------------------------------------

--- a/tests/resource_management/cleanup/test_handlers_vpc.py
+++ b/tests/resource_management/cleanup/test_handlers_vpc.py
@@ -1,10 +1,11 @@
-"""Tests for VPC pre-delete discovery hook."""
+"""Tests for VPC and Internet Gateway pre-delete discovery hooks."""
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from aws_bench.resource_management.cleanup.handlers.vpc import (
+    _clear_igw_public_address_wedge,
     _discover_vpc_dynamic_resources,
 )
 from aws_bench.resource_management.cleanup.models import StackResource
@@ -35,4 +36,37 @@ def test_discover_vpc_skips_non_vpc_resources():
     session = MagicMock()
     resources = [StackResource("L1", "bucket", "AWS::S3::Bucket", "CREATE_COMPLETE")]
     result = _discover_vpc_dynamic_resources(resources, session)
+    assert result == []
+
+
+# -- Internet Gateway wedge hook --
+
+_VPC_MOD = "aws_bench.resource_management.cleanup.handlers.vpc"
+
+
+def test_igw_hook_resolves_vpc_and_clears_wedge():
+    session = MagicMock()
+    resources = [StackResource("Igw", "igw-1", "AWS::EC2::InternetGateway", "CREATE_COMPLETE")]
+    with patch(f"{_VPC_MOD}.clear_igw_public_address_wedge") as mock_clear:
+        result = _clear_igw_public_address_wedge(resources, session)
+    mock_clear.assert_called_once_with(session, ["igw-1"])
+    # The hook discovers no new resources (the teardown deletes the IGW itself).
+    assert result == []
+
+
+def test_igw_hook_skips_when_no_igw():
+    session = MagicMock()
+    resources = [StackResource("L1", "vpc-1", "AWS::EC2::VPC", "CREATE_COMPLETE")]
+    with patch(f"{_VPC_MOD}.clear_igw_public_address_wedge") as mock_clear:
+        result = _clear_igw_public_address_wedge(resources, session)
+    mock_clear.assert_not_called()
+    assert result == []
+
+
+def test_igw_hook_skips_igw_without_physical_id():
+    session = MagicMock()
+    resources = [StackResource("Igw", "", "AWS::EC2::InternetGateway", "CREATE_COMPLETE")]
+    with patch(f"{_VPC_MOD}.clear_igw_public_address_wedge") as mock_clear:
+        result = _clear_igw_public_address_wedge(resources, session)
+    mock_clear.assert_not_called()
     assert result == []

--- a/tests/resource_management/cleanup/test_manager_integration.py
+++ b/tests/resource_management/cleanup/test_manager_integration.py
@@ -17,6 +17,7 @@ from aws_bench.resource_management.cleanup.models import (
     SnapshotResources,
     StackDeletionResult,
     StackDeletionStatus,
+    StackResource,
 )
 from aws_bench.resource_management.exceptions import SnapshotNotFoundError
 from aws_bench.resource_management.snapshot.models import SnapshotStage
@@ -304,6 +305,60 @@ def test_cleanup_stack_success(manager):
         assert summary.regions[0].region == "us-west-2"
         assert summary.regions[0].stacks_deleted == 1
         assert summary.regions[0].stacks_failed_count == 0
+        # A clean delete abandons nothing.
+        assert summary.regions[0].orphan_count == 0
+        assert summary.orphaned_resources == {}
+
+
+def test_cleanup_stack_surfaces_abandoned_as_orphans(manager):
+    """A FORCE_DELETE-abandoned resource is surfaced as an orphan on the single-stack path.
+
+    The single-stack path runs no orphan scan, so the abandoned resources riding on
+    StackDeletionResult are the only record — they must land in orphaned_resources with
+    orphan_count == len(abandoned) so reset can fail closed.
+    """
+    mock_deleter = MagicMock()
+    mock_result = StackDeletionResult(
+        stack_name="my-stack",
+        status=StackDeletionStatus.SUCCESS,
+        abandoned_resources=[
+            StackResource(
+                logical_id="Igw",
+                physical_id="igw-abandoned",
+                resource_type="AWS::EC2::InternetGateway",
+                status="DELETE_FAILED",
+            ),
+            # No physical id — falls back to the logical id.
+            StackResource(
+                logical_id="Bucket",
+                physical_id="",
+                resource_type="AWS::S3::Bucket",
+                status="DELETE_FAILED",
+            ),
+        ],
+    )
+    mock_deleter.delete_stack = AsyncMock(return_value=mock_result)
+
+    with (
+        patch.object(
+            manager, "_find_stack_region", new_callable=AsyncMock, return_value="us-west-2"
+        ),
+        patch.object(manager, "_write_metadata"),
+        patch(
+            "aws_bench.resource_management.cleanup.manager.StackDeleter",
+            return_value=mock_deleter,
+        ),
+        patch.object(manager, "_log_summary"),
+        patch.object(manager, "_save_summary"),
+    ):
+        summary = asyncio.run(manager.cleanup_stack("my-stack"))
+
+        assert summary.regions[0].stacks_deleted == 1
+        assert summary.regions[0].orphan_count == 2
+        assert summary.orphaned_resources == {
+            "AWS::EC2::InternetGateway": ["igw-abandoned"],
+            "AWS::S3::Bucket": ["Bucket"],
+        }
 
 
 def test_cleanup_stack_not_found(manager):

--- a/tests/resource_management/cleanup/test_stack_deleter.py
+++ b/tests/resource_management/cleanup/test_stack_deleter.py
@@ -951,8 +951,33 @@ def test_force_delete_failed_stack_success_flips_to_success(deleter):
         }
     ]
     result = StackDeletionResult(stack_name="my-stack", status=StackDeletionStatus.FAILED)
-    with patch.object(
-        deleter, "_poll_deletion", new_callable=AsyncMock, return_value="DELETE_COMPLETE"
+    # Drive the sweep so Bucket stays a stuck survivor: it verifies EXISTS and the
+    # cleaner fails to delete it. abandoned_resources then carries only that survivor.
+    failed_resource = Resource(type="AWS::S3::Bucket", identifier="my-bucket")
+    with (
+        patch.object(
+            deleter, "_poll_deletion", new_callable=AsyncMock, return_value="DELETE_COMPLETE"
+        ),
+        patch.object(
+            deleter._verifier,
+            "verify_resources",
+            new_callable=AsyncMock,
+            return_value=[
+                ResourceVerificationResult(
+                    logical_id="Bucket",
+                    physical_id="my-bucket",
+                    resource_type="AWS::S3::Bucket",
+                    cfn_status="DELETE_FAILED",
+                    existence_status=ExistenceStatus.EXISTS,
+                )
+            ],
+        ),
+        patch.object(
+            deleter._cleaner,
+            "cleanup",
+            new_callable=AsyncMock,
+            return_value={failed_resource: DeletionFailureEvent(status_message="AccessDenied")},
+        ),
     ):
         asyncio.run(deleter._force_delete_failed_stack("my-stack", result))
 
@@ -963,6 +988,11 @@ def test_force_delete_failed_stack_success_flips_to_success(deleter):
     assert result.reason == ""
     assert "Bucket" in deleter._manifest["my-stack"]["force_deleted"]
     assert "Fn" not in deleter._manifest["my-stack"]["force_deleted"]
+    # Only the survivor the sweep could not delete rides on the result as an orphan;
+    # everything the sweep reaped is excluded so it does not false-positive.
+    assert [r.logical_id for r in result.abandoned_resources] == ["Bucket"]
+    assert result.abandoned_resources[0].resource_type == "AWS::S3::Bucket"
+    assert result.abandoned_resources[0].physical_id == "my-bucket"
 
 
 def test_force_delete_failed_stack_no_op_when_not_delete_failed(deleter):
@@ -1045,6 +1075,7 @@ def test_force_delete_failed_stack_finalizes_when_no_resources_remain(deleter):
     assert result.status == StackDeletionStatus.SUCCESS
     assert result.reason == ""
     assert "force_deleted" not in deleter._manifest.get("my-stack", {})
+    assert result.abandoned_resources == []
 
 
 # -- _sweep_force_abandoned --

--- a/tests/resource_management/cleanup/test_stack_deleter.py
+++ b/tests/resource_management/cleanup/test_stack_deleter.py
@@ -13,6 +13,7 @@ from aws_bench.resource_management.ccapi.models import DeletionFailureEvent
 from aws_bench.resource_management.cleanup.handlers.cross_service import (
     EniReapResult,
     IpamPoolReapResult,
+    VpcPublicAddressWedgeResult,
 )
 from aws_bench.resource_management.cleanup.models import (
     ExistenceStatus,
@@ -798,6 +799,97 @@ def test_reap_and_retry_networking_retries_when_vpc_left_eni_clear(deleter):
         asyncio.run(deleter._reap_and_retry_networking("eks-stack", result))
     mock_reap.assert_called_once()
     deleter._client.delete_stack.assert_called_once_with(StackName="eks-stack")
+    assert result.status == StackDeletionStatus.SUCCESS
+
+
+def test_reap_and_retry_networking_clears_wedge_before_reap_and_records_manifest(deleter):
+    # The single-stack retry path must clear the NAT/EIP/IGW wedge (which the shared
+    # hooks never run here) BEFORE the ENI reap — a NAT gateway holds its own ENI —
+    # and record what it did in the manifest alongside the eni_reap entry.
+    result = StackDeletionResult(
+        stack_name="net-stack",
+        status=StackDeletionStatus.FAILED,
+        resources=[StackResource("Vpc", "vpc-1", "AWS::EC2::VPC", "DELETE_FAILED")],
+    )
+    deleter._poll_deletion = AsyncMock(return_value="DELETE_COMPLETE")
+    call_order: list[str] = []
+    wedge = VpcPublicAddressWedgeResult(
+        nat_deleted=["nat-1"], eips_released=["eipalloc-1"], igws_deleted=["igw-1"]
+    )
+    with (
+        patch(
+            "aws_bench.resource_management.cleanup.stack_deleter.clear_vpc_public_address_wedge",
+            side_effect=lambda *a, **k: call_order.append("wedge") or wedge,
+        ) as mock_wedge,
+        patch(
+            "aws_bench.resource_management.cleanup.stack_deleter.reap_vpc_enis",
+            side_effect=lambda *a, **k: (
+                call_order.append("enis") or EniReapResult(deleted=["eni-1"])
+            ),
+        ) as mock_reap,
+    ):
+        asyncio.run(deleter._reap_and_retry_networking("net-stack", result))
+
+    mock_wedge.assert_called_once()
+    mock_reap.assert_called_once()
+    assert call_order == ["wedge", "enis"]  # wedge cleared before the ENI reap
+    deleter._client.delete_stack.assert_called_once_with(StackName="net-stack")
+    assert result.status == StackDeletionStatus.SUCCESS
+    teardown = deleter._manifest["net-stack"]["nat_eip_igw_teardown"]
+    assert teardown["nat_deleted"] == ["nat-1"]
+    assert teardown["eips_released"] == ["eipalloc-1"]
+    assert teardown["igws_deleted"] == ["igw-1"]
+    assert teardown["remaining"] == []
+
+
+def test_reap_and_retry_networking_no_retry_when_only_wedge_orphans(deleter):
+    # The wedge could not fully clear (a NAT gateway never reached 'deleted') and the
+    # ENI reap found nothing to do: no progress + orphans means a retry would stall,
+    # so DeleteStack is not re-issued and the orphan is recorded.
+    result = StackDeletionResult(
+        stack_name="net-stack",
+        status=StackDeletionStatus.FAILED,
+        resources=[StackResource("Vpc", "vpc-1", "AWS::EC2::VPC", "DELETE_FAILED")],
+    )
+    deleter._poll_deletion = AsyncMock()
+    with (
+        patch(
+            "aws_bench.resource_management.cleanup.stack_deleter.clear_vpc_public_address_wedge",
+            return_value=VpcPublicAddressWedgeResult(remaining=["nat-slow"]),
+        ),
+        patch(
+            "aws_bench.resource_management.cleanup.stack_deleter.reap_vpc_enis",
+            return_value=EniReapResult(),
+        ),
+    ):
+        asyncio.run(deleter._reap_and_retry_networking("net-stack", result))
+    deleter._client.delete_stack.assert_not_called()
+    deleter._poll_deletion.assert_not_awaited()
+    assert result.status == StackDeletionStatus.FAILED
+    assert deleter._manifest["net-stack"]["nat_eip_igw_teardown"]["remaining"] == ["nat-slow"]
+
+
+def test_reap_and_retry_networking_retries_when_only_wedge_made_progress(deleter):
+    # The ENI reap found nothing (reaped_any False) but the wedge deleted a NAT gateway
+    # (cleared_any True), so progress WAS made — the retry must still fire.
+    result = StackDeletionResult(
+        stack_name="net-stack",
+        status=StackDeletionStatus.FAILED,
+        resources=[StackResource("Vpc", "vpc-1", "AWS::EC2::VPC", "DELETE_FAILED")],
+    )
+    deleter._poll_deletion = AsyncMock(return_value="DELETE_COMPLETE")
+    with (
+        patch(
+            "aws_bench.resource_management.cleanup.stack_deleter.clear_vpc_public_address_wedge",
+            return_value=VpcPublicAddressWedgeResult(nat_deleted=["nat-1"]),
+        ),
+        patch(
+            "aws_bench.resource_management.cleanup.stack_deleter.reap_vpc_enis",
+            return_value=EniReapResult(),
+        ),
+    ):
+        asyncio.run(deleter._reap_and_retry_networking("net-stack", result))
+    deleter._client.delete_stack.assert_called_once_with(StackName="net-stack")
     assert result.status == StackDeletionStatus.SUCCESS
 
 

--- a/tests/resource_management/reset/test_reset_manager.py
+++ b/tests/resource_management/reset/test_reset_manager.py
@@ -13,7 +13,12 @@ from aws_bench.account_management.models import ScenarioAccount
 from aws_bench.resource_management import deferred
 from aws_bench.resource_management.ccapi.models import Resource
 from aws_bench.resource_management.reset.manager import ResetManager
-from aws_bench.resource_management.reset.models import ResetFailure, ResetResult, RestoreOutcome
+from aws_bench.resource_management.reset.models import (
+    ResetFailure,
+    ResetResult,
+    ResetupDeletion,
+    RestoreOutcome,
+)
 from aws_bench.resource_management.snapshot.models import (
     DriftBaseline,
     ResourceDrift,
@@ -450,7 +455,7 @@ def test_reset_account_fixes_drift(temp_output_dir, sample_snapshot, tmp_path):
 
                 # Make the mock coroutine
                 async def mock_restore_coro(*args, **kwargs):
-                    return RestoreOutcome.RESTORED
+                    return ResetupDeletion(RestoreOutcome.RESTORED)
 
                 mock_restore.side_effect = mock_restore_coro
 
@@ -501,7 +506,7 @@ def test_reset_account_flags_redeploy_when_stack_deleted(temp_output_dir, sample
         )
 
         async def mock_restore_coro(*args, **kwargs):
-            return RestoreOutcome.DELETED_NEEDS_REDEPLOY
+            return ResetupDeletion(RestoreOutcome.DELETED_NEEDS_REDEPLOY)
 
         mock_restore.side_effect = mock_restore_coro
 
@@ -565,7 +570,7 @@ def test_reset_account_fails_closed_on_orphan_after_stack_delete(temp_output_dir
         )
 
         async def mock_restore_coro(*args, **kwargs):
-            return RestoreOutcome.DELETED_NEEDS_REDEPLOY
+            return ResetupDeletion(RestoreOutcome.DELETED_NEEDS_REDEPLOY)
 
         mock_restore.side_effect = mock_restore_coro
 
@@ -576,6 +581,69 @@ def test_reset_account_fails_closed_on_orphan_after_stack_delete(temp_output_dir
     assert result.success is False
     assert result.needs_redeploy is False
     assert result.unresolved_orphans == orphan
+
+
+@mock_aws
+def test_reset_account_fails_closed_on_force_abandoned_even_when_scan_clean(
+    temp_output_dir, sample_snapshot
+):
+    """A force-delete-abandoned resource fails the reset even when the scan is clean.
+
+    Core regression for this fix: FORCE_DELETE_STACK can abandon a wedged resource
+    (e.g. a leaked IGW) that the single-stack cleanup path never scans for. If the
+    orphan census (find_orphan_resources) can't enumerate that type it returns a
+    clean result (None), which used to let the deleted-stack early return absorb the
+    survivor into a fresh baseline. The abandoned resource now rides on the deletion
+    result, so reset must FAIL CLOSED and name it in unresolved_orphans even though
+    the scan found nothing.
+    """
+    session = boto3.Session(region_name="us-east-1")
+    manager = ResetManager(session, output_dir=temp_output_dir)
+
+    drift_differences = {
+        "test-stack": {
+            "baseline": [{"LogicalResourceId": "MyRole", "StackResourceDriftStatus": "IN_SYNC"}],
+            "current": [{"LogicalResourceId": "MyRole", "StackResourceDriftStatus": "MODIFIED"}],
+        }
+    }
+    abandoned = {"AWS::EC2::InternetGateway": [{"Identifier": "igw-abandoned"}]}
+
+    with (
+        patch(
+            "aws_bench.resource_management.verify.manager.SnapshotManager.load_snapshot"
+        ) as mock_load,
+        patch(
+            "aws_bench.resource_management.verify.manager.VerifyManager.verify_account_state"
+        ) as mock_verify,
+        patch(
+            "aws_bench.resource_management.verify.manager.VerifyManager.find_orphan_resources",
+            return_value=None,
+        ) as mock_orphan,
+        patch(
+            "aws_bench.resource_management.reset.stack_restorer.StackRestorer.restore_stack"
+        ) as mock_restore,
+    ):
+        mock_load.return_value = sample_snapshot
+        mock_verify.return_value = VerifyResult(
+            success=False,
+            reason="1 stack has different drift",
+            drift_differences=drift_differences,
+        )
+
+        # Revert impossible: the stack is deleted for re-setup, and FORCE_DELETE_STACK
+        # abandoned an IGW that rides back on the deletion result.
+        async def mock_restore_coro(*args, **kwargs):
+            return ResetupDeletion(RestoreOutcome.DELETED_NEEDS_REDEPLOY, abandoned=abandoned)
+
+        mock_restore.side_effect = mock_restore_coro
+
+        result = asyncio.run(manager.reset_account("test-env", "123456789012"))
+
+    # Scan was clean, yet the abandoned resource still fails the reset by name.
+    mock_orphan.assert_called_once()
+    assert result.success is False
+    assert result.needs_redeploy is False
+    assert result.unresolved_orphans == abandoned
 
 
 # ===========================================================================
@@ -636,7 +704,7 @@ def test_reset_account_remediates_delete_failed_stack_alongside_new_resources(
         mock_del_new.side_effect = _del_new_coro
 
         async def _delete_stack_coro(*args, **kwargs):
-            return RestoreOutcome.DELETED_NEEDS_REDEPLOY
+            return ResetupDeletion(RestoreOutcome.DELETED_NEEDS_REDEPLOY)
 
         mock_delete_stack.side_effect = _delete_stack_coro
 
@@ -690,7 +758,7 @@ def test_reset_account_recreates_drift_undetectable_stack(temp_output_dir, sampl
         mock_verify.return_value = aggregated
 
         async def _delete_stack_coro(*args, **kwargs):
-            return RestoreOutcome.DELETED_NEEDS_REDEPLOY
+            return ResetupDeletion(RestoreOutcome.DELETED_NEEDS_REDEPLOY)
 
         mock_delete_stack.side_effect = _delete_stack_coro
 
@@ -733,7 +801,7 @@ def test_reset_account_drift_undetectable_delete_failure_raises(temp_output_dir,
                 mock_verify.return_value = aggregated
 
                 async def _delete_stack_coro(*args, **kwargs):
-                    return RestoreOutcome.FAILED
+                    return ResetupDeletion(RestoreOutcome.FAILED)
 
                 mock_delete_stack.side_effect = _delete_stack_coro
 
@@ -781,7 +849,7 @@ def test_reset_account_drift_undetectable_skipped_when_already_status_deleted(
         mock_verify.return_value = aggregated
 
         async def _delete_stack_coro(*args, **kwargs):
-            return RestoreOutcome.DELETED_NEEDS_REDEPLOY
+            return ResetupDeletion(RestoreOutcome.DELETED_NEEDS_REDEPLOY)
 
         mock_delete_stack.side_effect = _delete_stack_coro
 
@@ -839,7 +907,7 @@ def test_reset_account_recreates_template_mismatched_stack(temp_output_dir, samp
         mock_verify.return_value = aggregated
 
         async def _delete_stack_coro(*args, **kwargs):
-            return RestoreOutcome.DELETED_NEEDS_REDEPLOY
+            return ResetupDeletion(RestoreOutcome.DELETED_NEEDS_REDEPLOY)
 
         mock_delete_stack.side_effect = _delete_stack_coro
 
@@ -890,10 +958,12 @@ def test_delete_unrecoverable_stacks_includes_template_mismatch(temp_output_dir)
         template_mismatch_stacks=["s3-stack"],
     )
     restorer = MagicMock()
-    restorer._delete_for_resetup = AsyncMock(return_value=RestoreOutcome.DELETED_NEEDS_REDEPLOY)
+    restorer._delete_for_resetup = AsyncMock(
+        return_value=ResetupDeletion(RestoreOutcome.DELETED_NEEDS_REDEPLOY)
+    )
 
     deleted = asyncio.run(manager._delete_unrecoverable_stacks(verify_result, restorer))
-    assert deleted == ["s3-stack"]
+    assert deleted.deleted_stacks == ["s3-stack"]
     restorer._delete_for_resetup.assert_called_once()
     assert restorer._delete_for_resetup.call_args.args[0] == "s3-stack"
 
@@ -937,7 +1007,7 @@ def test_reset_account_stack_restoration_fails(temp_output_dir, sample_snapshot,
 
                 # Make the mock coroutine return FAILED (restoration fails)
                 async def mock_restore_coro(*args, **kwargs):
-                    return RestoreOutcome.FAILED
+                    return ResetupDeletion(RestoreOutcome.FAILED)
 
                 mock_restore.side_effect = mock_restore_coro
 
@@ -1029,7 +1099,7 @@ def test_stack_restorer_restore_stack_attempts_revert(temp_output_dir):
         )
 
     # Should succeed with revert path
-    assert success is RestoreOutcome.RESTORED
+    assert success.outcome is RestoreOutcome.RESTORED
     # Verify changeset was attempted
     mock_create.assert_called_once()
 
@@ -1058,6 +1128,7 @@ def test_stack_restorer_deletes_for_resetup_when_revert_fails(temp_output_dir):
 
             cleanup_result = MagicMock()
             cleanup_result.all_stacks_succeeded = True
+            cleanup_result.orphaned_resources = {}
 
             async def cleanup_coro(*args, **kwargs):
                 return cleanup_result
@@ -1071,7 +1142,7 @@ def test_stack_restorer_deletes_for_resetup_when_revert_fails(temp_output_dir):
                 )
             )
 
-    assert outcome is RestoreOutcome.DELETED_NEEDS_REDEPLOY
+    assert outcome.outcome is RestoreOutcome.DELETED_NEEDS_REDEPLOY
     mock_cleanup.assert_called_once_with("test-stack")
 
 
@@ -1090,7 +1161,7 @@ def test_delete_unrecoverable_stacks_no_failures(temp_output_dir):
     restorer = MagicMock()
 
     deleted = asyncio.run(manager._delete_unrecoverable_stacks(verify_result, restorer))
-    assert deleted == []
+    assert deleted.deleted_stacks == []
 
 
 @mock_aws
@@ -1107,7 +1178,7 @@ def test_delete_unrecoverable_stacks_missing_stack(temp_output_dir):
     restorer = MagicMock()
 
     deleted = asyncio.run(manager._delete_unrecoverable_stacks(verify_result, restorer))
-    assert deleted == ["my-stack"]
+    assert deleted.deleted_stacks == ["my-stack"]
     restorer._delete_for_resetup.assert_not_called()
 
 
@@ -1125,10 +1196,12 @@ def test_delete_unrecoverable_stacks_wrong_status_deleted(temp_output_dir):
         },
     )
     restorer = MagicMock()
-    restorer._delete_for_resetup = AsyncMock(return_value=RestoreOutcome.DELETED_NEEDS_REDEPLOY)
+    restorer._delete_for_resetup = AsyncMock(
+        return_value=ResetupDeletion(RestoreOutcome.DELETED_NEEDS_REDEPLOY)
+    )
 
     deleted = asyncio.run(manager._delete_unrecoverable_stacks(verify_result, restorer))
-    assert deleted == ["bad-stack"]
+    assert deleted.deleted_stacks == ["bad-stack"]
 
 
 @mock_aws
@@ -1143,10 +1216,12 @@ def test_delete_unrecoverable_stacks_undetectable_deleted(temp_output_dir):
         drift_undetectable=["ecsroll-stack"],
     )
     restorer = MagicMock()
-    restorer._delete_for_resetup = AsyncMock(return_value=RestoreOutcome.DELETED_NEEDS_REDEPLOY)
+    restorer._delete_for_resetup = AsyncMock(
+        return_value=ResetupDeletion(RestoreOutcome.DELETED_NEEDS_REDEPLOY)
+    )
 
     deleted = asyncio.run(manager._delete_unrecoverable_stacks(verify_result, restorer))
-    assert deleted == ["ecsroll-stack"]
+    assert deleted.deleted_stacks == ["ecsroll-stack"]
     restorer._delete_for_resetup.assert_called_once()
     assert restorer._delete_for_resetup.call_args.args[0] == "ecsroll-stack"
 
@@ -1166,10 +1241,12 @@ def test_delete_unrecoverable_stacks_dedupes_status_and_undetectable(temp_output
         drift_undetectable=["dup-stack"],
     )
     restorer = MagicMock()
-    restorer._delete_for_resetup = AsyncMock(return_value=RestoreOutcome.DELETED_NEEDS_REDEPLOY)
+    restorer._delete_for_resetup = AsyncMock(
+        return_value=ResetupDeletion(RestoreOutcome.DELETED_NEEDS_REDEPLOY)
+    )
 
     deleted = asyncio.run(manager._delete_unrecoverable_stacks(verify_result, restorer))
-    assert deleted == ["dup-stack"]
+    assert deleted.deleted_stacks == ["dup-stack"]
     restorer._delete_for_resetup.assert_called_once()
 
 
@@ -1187,7 +1264,7 @@ def test_delete_unrecoverable_stacks_delete_fails_raises(temp_output_dir):
         },
     )
     restorer = MagicMock()
-    restorer._delete_for_resetup = AsyncMock(return_value=RestoreOutcome.FAILED)
+    restorer._delete_for_resetup = AsyncMock(return_value=ResetupDeletion(RestoreOutcome.FAILED))
 
     with pytest.raises(ResetFailure):
         asyncio.run(manager._delete_unrecoverable_stacks(verify_result, restorer))
@@ -1212,13 +1289,13 @@ def test_restore_drifted_stacks_skips_already_handled(temp_output_dir):
         drift_differences={"rds-stack": {"baseline": [], "current": []}},
     )
     restorer = MagicMock()
-    restorer.restore_stack = AsyncMock(return_value=RestoreOutcome.RESTORED)
+    restorer.restore_stack = AsyncMock(return_value=ResetupDeletion(RestoreOutcome.RESTORED))
 
     deleted = asyncio.run(
         manager._restore_drifted_stacks(verify_result, restorer, already_handled={"rds-stack"})
     )
 
-    assert deleted == []
+    assert deleted.deleted_stacks == []
     restorer.restore_stack.assert_not_called()
 
 
@@ -1234,13 +1311,13 @@ def test_restore_drifted_stacks_restores_unhandled(temp_output_dir):
         drift_differences={"other-stack": {"baseline": [], "current": []}},
     )
     restorer = MagicMock()
-    restorer.restore_stack = AsyncMock(return_value=RestoreOutcome.RESTORED)
+    restorer.restore_stack = AsyncMock(return_value=ResetupDeletion(RestoreOutcome.RESTORED))
 
     deleted = asyncio.run(
         manager._restore_drifted_stacks(verify_result, restorer, already_handled={"rds-stack"})
     )
 
-    assert deleted == []
+    assert deleted.deleted_stacks == []
     restorer.restore_stack.assert_called_once()
 
 

--- a/tests/resource_management/reset/test_reset_manager.py
+++ b/tests/resource_management/reset/test_reset_manager.py
@@ -474,38 +474,108 @@ def test_reset_account_flags_redeploy_when_stack_deleted(temp_output_dir, sample
         }
     }
 
-    with patch(
-        "aws_bench.resource_management.verify.manager.SnapshotManager.load_snapshot"
-    ) as mock_load:
-        with patch(
+    with (
+        patch(
+            "aws_bench.resource_management.verify.manager.SnapshotManager.load_snapshot"
+        ) as mock_load,
+        patch(
             "aws_bench.resource_management.verify.manager.VerifyManager.verify_account_state"
-        ) as mock_verify:
-            with patch(
-                "aws_bench.resource_management.reset.stack_restorer.StackRestorer.restore_stack"
-            ) as mock_restore:
-                mock_load.return_value = sample_snapshot
+        ) as mock_verify,
+        patch(
+            "aws_bench.resource_management.verify.manager.VerifyManager.find_orphan_resources",
+            return_value=None,
+        ) as mock_orphan,
+        patch(
+            "aws_bench.resource_management.reset.stack_restorer.StackRestorer.restore_stack"
+        ) as mock_restore,
+    ):
+        mock_load.return_value = sample_snapshot
 
-                # Verification finds drift; final verify should NOT run because
-                # the stack is deleted (redeploy pending).
-                mock_verify.return_value = VerifyResult(
-                    success=False,
-                    reason="1 stack has different drift",
-                    drift_differences=drift_differences,
-                )
+        # Verification finds drift; the region-wide stack/drift re-verify should NOT
+        # run because the stack is deleted (redeploy pending) — but the orphan
+        # census still runs as the fail-closed backstop and finds nothing here.
+        mock_verify.return_value = VerifyResult(
+            success=False,
+            reason="1 stack has different drift",
+            drift_differences=drift_differences,
+        )
 
-                async def mock_restore_coro(*args, **kwargs):
-                    return RestoreOutcome.DELETED_NEEDS_REDEPLOY
+        async def mock_restore_coro(*args, **kwargs):
+            return RestoreOutcome.DELETED_NEEDS_REDEPLOY
 
-                mock_restore.side_effect = mock_restore_coro
+        mock_restore.side_effect = mock_restore_coro
 
-                result = asyncio.run(manager.reset_account("test-env", "123456789012"))
+        result = asyncio.run(manager.reset_account("test-env", "123456789012"))
 
     assert result.success
     assert result.needs_redeploy is True
     assert result.details is not None
     assert result.details["deleted_stacks"] == ["test-stack"]
-    # Final verify must be skipped (only the initial verify ran).
+    # Final stack/drift verify skipped (only the initial verify ran); the orphan
+    # census ran as the backstop and was clean.
     assert mock_verify.call_count == 1
+    mock_orphan.assert_called_once()
+
+
+@mock_aws
+def test_reset_account_fails_closed_on_orphan_after_stack_delete(temp_output_dir, sample_snapshot):
+    """A stack delete must NOT suppress a still-present orphan resource.
+
+    Regression for the loophole: a leaked resource that reset tried and failed to
+    delete used to be masked by the deleted-stack early return, then absorbed into a
+    fresh baseline. Now the orphan census runs as a fail-closed backstop — reset
+    must FAIL and surface the orphan by name in unresolved_orphans.
+    """
+    session = boto3.Session(region_name="us-east-1")
+    manager = ResetManager(session, output_dir=temp_output_dir)
+
+    drift_differences = {
+        "test-stack": {
+            "baseline": [{"LogicalResourceId": "MyRole", "StackResourceDriftStatus": "IN_SYNC"}],
+            "current": [{"LogicalResourceId": "MyRole", "StackResourceDriftStatus": "MODIFIED"}],
+        }
+    }
+    orphan = {"AWS::EC2::InternetGateway": [{"Identifier": "igw-leaked"}]}
+
+    with (
+        patch(
+            "aws_bench.resource_management.verify.manager.SnapshotManager.load_snapshot"
+        ) as mock_load,
+        patch(
+            "aws_bench.resource_management.verify.manager.VerifyManager.verify_account_state"
+        ) as mock_verify,
+        patch(
+            "aws_bench.resource_management.verify.manager.VerifyManager.find_orphan_resources",
+            return_value=VerifyResult(
+                success=False,
+                reason="Found 1 new resource(s)",
+                new_resources=orphan,
+                suggestion="Run 'aws-bench env reset' to remove new resources",
+            ),
+        ) as mock_orphan,
+        patch(
+            "aws_bench.resource_management.reset.stack_restorer.StackRestorer.restore_stack"
+        ) as mock_restore,
+    ):
+        mock_load.return_value = sample_snapshot
+        mock_verify.return_value = VerifyResult(
+            success=False,
+            reason="1 stack has different drift",
+            drift_differences=drift_differences,
+        )
+
+        async def mock_restore_coro(*args, **kwargs):
+            return RestoreOutcome.DELETED_NEEDS_REDEPLOY
+
+        mock_restore.side_effect = mock_restore_coro
+
+        result = asyncio.run(manager.reset_account("test-env", "123456789012"))
+
+    # The deleted stack did NOT suppress the orphan: reset failed and named it.
+    mock_orphan.assert_called_once()
+    assert result.success is False
+    assert result.needs_redeploy is False
+    assert result.unresolved_orphans == orphan
 
 
 # ===========================================================================
@@ -537,35 +607,40 @@ def test_reset_account_remediates_delete_failed_stack_alongside_new_resources(
         },
     )
 
-    with patch(
-        "aws_bench.resource_management.verify.manager.SnapshotManager.load_snapshot"
-    ) as mock_load:
-        with patch(
+    with (
+        patch(
+            "aws_bench.resource_management.verify.manager.SnapshotManager.load_snapshot"
+        ) as mock_load,
+        patch(
             "aws_bench.resource_management.verify.manager.VerifyManager.verify_account_state"
-        ) as mock_verify:
-            with patch(
-                "aws_bench.resource_management.reset.manager.ResetManager._delete_new_resources"
-            ) as mock_del_new:
-                with patch(
-                    "aws_bench.resource_management.reset.stack_restorer."
-                    "StackRestorer._delete_for_resetup"
-                ) as mock_delete_stack:
-                    mock_load.return_value = sample_snapshot
-                    # Diagnosis returns the aggregated failure; no final verify
-                    # runs because the stack is deleted for redeploy.
-                    mock_verify.return_value = aggregated
+        ) as mock_verify,
+        patch(
+            "aws_bench.resource_management.verify.manager.VerifyManager.find_orphan_resources",
+            return_value=None,
+        ),
+        patch(
+            "aws_bench.resource_management.reset.manager.ResetManager._delete_new_resources"
+        ) as mock_del_new,
+        patch(
+            "aws_bench.resource_management.reset.stack_restorer.StackRestorer._delete_for_resetup"
+        ) as mock_delete_stack,
+    ):
+        mock_load.return_value = sample_snapshot
+        # Diagnosis returns the aggregated failure; no final stack/drift verify
+        # runs because the stack is deleted for redeploy.
+        mock_verify.return_value = aggregated
 
-                    async def _del_new_coro(*args, **kwargs):
-                        return {}  # no global resources deferred in this case
+        async def _del_new_coro(*args, **kwargs):
+            return {}  # no global resources deferred in this case
 
-                    mock_del_new.side_effect = _del_new_coro
+        mock_del_new.side_effect = _del_new_coro
 
-                    async def _delete_stack_coro(*args, **kwargs):
-                        return RestoreOutcome.DELETED_NEEDS_REDEPLOY
+        async def _delete_stack_coro(*args, **kwargs):
+            return RestoreOutcome.DELETED_NEEDS_REDEPLOY
 
-                    mock_delete_stack.side_effect = _delete_stack_coro
+        mock_delete_stack.side_effect = _delete_stack_coro
 
-                    result = asyncio.run(manager.reset_account("test-env", "123456789012"))
+        result = asyncio.run(manager.reset_account("test-env", "123456789012"))
 
     # The DELETE_FAILED stack was routed to deletion-for-resetup...
     mock_delete_stack.assert_called_once()
@@ -596,25 +671,30 @@ def test_reset_account_recreates_drift_undetectable_stack(temp_output_dir, sampl
         drift_undetectable=["ecsroll-stack"],
     )
 
-    with patch(
-        "aws_bench.resource_management.verify.manager.SnapshotManager.load_snapshot"
-    ) as mock_load:
-        with patch(
+    with (
+        patch(
+            "aws_bench.resource_management.verify.manager.SnapshotManager.load_snapshot"
+        ) as mock_load,
+        patch(
             "aws_bench.resource_management.verify.manager.VerifyManager.verify_account_state"
-        ) as mock_verify:
-            with patch(
-                "aws_bench.resource_management.reset.stack_restorer."
-                "StackRestorer._delete_for_resetup"
-            ) as mock_delete_stack:
-                mock_load.return_value = sample_snapshot
-                mock_verify.return_value = aggregated
+        ) as mock_verify,
+        patch(
+            "aws_bench.resource_management.verify.manager.VerifyManager.find_orphan_resources",
+            return_value=None,
+        ),
+        patch(
+            "aws_bench.resource_management.reset.stack_restorer.StackRestorer._delete_for_resetup"
+        ) as mock_delete_stack,
+    ):
+        mock_load.return_value = sample_snapshot
+        mock_verify.return_value = aggregated
 
-                async def _delete_stack_coro(*args, **kwargs):
-                    return RestoreOutcome.DELETED_NEEDS_REDEPLOY
+        async def _delete_stack_coro(*args, **kwargs):
+            return RestoreOutcome.DELETED_NEEDS_REDEPLOY
 
-                mock_delete_stack.side_effect = _delete_stack_coro
+        mock_delete_stack.side_effect = _delete_stack_coro
 
-                result = asyncio.run(manager.reset_account("test-env", "123456789012"))
+        result = asyncio.run(manager.reset_account("test-env", "123456789012"))
 
     # Deleted for re-setup (classification already proved it's permanently gone).
     mock_delete_stack.assert_called_once()
@@ -623,7 +703,7 @@ def test_reset_account_recreates_drift_undetectable_stack(temp_output_dir, sampl
     assert result.needs_redeploy is True
     assert result.details is not None
     assert result.details["deleted_stacks"] == ["ecsroll-stack"]
-    # Final verify must be skipped (stack deleted for redeploy) — only initial ran.
+    # Final stack/drift verify skipped (stack deleted for redeploy) — only initial ran.
     assert mock_verify.call_count == 1
 
 
@@ -682,25 +762,30 @@ def test_reset_account_drift_undetectable_skipped_when_already_status_deleted(
         drift_undetectable=["dup-stack"],
     )
 
-    with patch(
-        "aws_bench.resource_management.verify.manager.SnapshotManager.load_snapshot"
-    ) as mock_load:
-        with patch(
+    with (
+        patch(
+            "aws_bench.resource_management.verify.manager.SnapshotManager.load_snapshot"
+        ) as mock_load,
+        patch(
             "aws_bench.resource_management.verify.manager.VerifyManager.verify_account_state"
-        ) as mock_verify:
-            with patch(
-                "aws_bench.resource_management.reset.stack_restorer."
-                "StackRestorer._delete_for_resetup"
-            ) as mock_delete_stack:
-                mock_load.return_value = sample_snapshot
-                mock_verify.return_value = aggregated
+        ) as mock_verify,
+        patch(
+            "aws_bench.resource_management.verify.manager.VerifyManager.find_orphan_resources",
+            return_value=None,
+        ),
+        patch(
+            "aws_bench.resource_management.reset.stack_restorer.StackRestorer._delete_for_resetup"
+        ) as mock_delete_stack,
+    ):
+        mock_load.return_value = sample_snapshot
+        mock_verify.return_value = aggregated
 
-                async def _delete_stack_coro(*args, **kwargs):
-                    return RestoreOutcome.DELETED_NEEDS_REDEPLOY
+        async def _delete_stack_coro(*args, **kwargs):
+            return RestoreOutcome.DELETED_NEEDS_REDEPLOY
 
-                mock_delete_stack.side_effect = _delete_stack_coro
+        mock_delete_stack.side_effect = _delete_stack_coro
 
-                result = asyncio.run(manager.reset_account("test-env", "123456789012"))
+        result = asyncio.run(manager.reset_account("test-env", "123456789012"))
 
     # The MISSING status stack is handled by Phase 2 (no delete call needed), and
     # Phase 2b must NOT act on it again (already_handled).
@@ -735,30 +820,35 @@ def test_reset_account_recreates_template_mismatched_stack(temp_output_dir, samp
         template_mismatch_stacks=["databases-and-storage-S3"],
     )
 
-    with patch(
-        "aws_bench.resource_management.verify.manager.SnapshotManager.load_snapshot"
-    ) as mock_load:
-        with patch(
+    with (
+        patch(
+            "aws_bench.resource_management.verify.manager.SnapshotManager.load_snapshot"
+        ) as mock_load,
+        patch(
             "aws_bench.resource_management.verify.manager.VerifyManager.verify_account_state"
-        ) as mock_verify:
-            with patch(
-                "aws_bench.resource_management.reset.stack_restorer."
-                "StackRestorer._delete_for_resetup"
-            ) as mock_delete_stack:
-                mock_load.return_value = sample_snapshot
-                mock_verify.return_value = aggregated
+        ) as mock_verify,
+        patch(
+            "aws_bench.resource_management.verify.manager.VerifyManager.find_orphan_resources",
+            return_value=None,
+        ),
+        patch(
+            "aws_bench.resource_management.reset.stack_restorer.StackRestorer._delete_for_resetup"
+        ) as mock_delete_stack,
+    ):
+        mock_load.return_value = sample_snapshot
+        mock_verify.return_value = aggregated
 
-                async def _delete_stack_coro(*args, **kwargs):
-                    return RestoreOutcome.DELETED_NEEDS_REDEPLOY
+        async def _delete_stack_coro(*args, **kwargs):
+            return RestoreOutcome.DELETED_NEEDS_REDEPLOY
 
-                mock_delete_stack.side_effect = _delete_stack_coro
+        mock_delete_stack.side_effect = _delete_stack_coro
 
-                result = asyncio.run(manager.reset_account("test-env", "123456789012"))
+        result = asyncio.run(manager.reset_account("test-env", "123456789012"))
 
     # Template-changed stack routed to delete-for-resetup...
     mock_delete_stack.assert_called_once()
     assert mock_delete_stack.call_args.args[0] == "databases-and-storage-S3"
-    # ...and reset succeeds with redeploy pending; final verify is skipped.
+    # ...and reset succeeds with redeploy pending; final stack/drift verify is skipped.
     assert result.success
     assert result.needs_redeploy is True
     assert result.details is not None

--- a/tests/resource_management/reset/test_reset_models.py
+++ b/tests/resource_management/reset/test_reset_models.py
@@ -23,6 +23,25 @@ def test_reset_result_creation():
     assert result.details == {"stacks_fixed": 2, "resources_deleted": 5}
 
 
+def test_reset_result_unresolved_orphans_defaults_none():
+    """unresolved_orphans defaults to None on a clean success result."""
+    result = ResetResult(success=True, reason="Account successfully reset to baseline state")
+
+    assert result.unresolved_orphans is None
+
+
+def test_reset_result_carries_unresolved_orphans():
+    """A failure result can carry the orphans reset could not resolve."""
+    orphans = {"AWS::EC2::InternetGateway": [{"Identifier": "igw-leaked"}]}
+    result = ResetResult(
+        success=False,
+        reason="Stacks deleted for re-setup, but reset left the region unresolved",
+        unresolved_orphans=orphans,
+    )
+
+    assert result.unresolved_orphans == orphans
+
+
 # ===========================================================================
 # ResetFailure — failure exception
 # ===========================================================================

--- a/tests/resource_management/reset/test_stack_restorer.py
+++ b/tests/resource_management/reset/test_stack_restorer.py
@@ -9,7 +9,7 @@ import pytest
 from moto import mock_aws
 
 from aws_bench.resource_management.cleanup.manager import CleanupManager
-from aws_bench.resource_management.reset.models import RestoreOutcome
+from aws_bench.resource_management.reset.models import ResetupDeletion, RestoreOutcome
 from aws_bench.resource_management.reset.stack_restorer import StackRestorer
 
 
@@ -51,7 +51,8 @@ def test_restore_stack_succeeds_with_drift_revert(restorer):
             )
         )
 
-    assert result is RestoreOutcome.RESTORED
+    assert result.outcome is RestoreOutcome.RESTORED
+    assert result.abandoned == {}
     mock_revert.assert_called_once()
 
 
@@ -64,7 +65,7 @@ def test_restore_stack_deletes_when_revert_fails(restorer):
         with patch.object(restorer, "_delete_for_resetup", new_callable=AsyncMock) as mock_delete:
             # Revert fails -> falls back to delete-for-resetup
             mock_revert.return_value = False
-            mock_delete.return_value = RestoreOutcome.DELETED_NEEDS_REDEPLOY
+            mock_delete.return_value = ResetupDeletion(RestoreOutcome.DELETED_NEEDS_REDEPLOY)
 
             result = asyncio.run(
                 restorer.restore_stack(
@@ -73,7 +74,7 @@ def test_restore_stack_deletes_when_revert_fails(restorer):
                 )
             )
 
-    assert result is RestoreOutcome.DELETED_NEEDS_REDEPLOY
+    assert result.outcome is RestoreOutcome.DELETED_NEEDS_REDEPLOY
     mock_revert.assert_called_once()
     mock_delete.assert_called_once_with("test-stack")
 
@@ -441,12 +442,40 @@ def test_delete_for_resetup_succeeds(restorer):
     ) as mock_cleanup:
         cleanup_result = MagicMock()
         cleanup_result.all_stacks_succeeded = True
+        cleanup_result.orphaned_resources = {}
         mock_cleanup.return_value = cleanup_result
 
         result = asyncio.run(restorer._delete_for_resetup("test-stack"))
 
-    assert result is RestoreOutcome.DELETED_NEEDS_REDEPLOY
+    assert result.outcome is RestoreOutcome.DELETED_NEEDS_REDEPLOY
+    assert result.abandoned == {}
     mock_cleanup.assert_called_once_with("test-stack")
+
+
+@mock_aws
+def test_delete_for_resetup_carries_abandoned_from_cleanup(restorer):
+    """Force-abandoned resources on cleanup_stack surface as ResetupDeletion.abandoned.
+
+    cleanup_stack reports FORCE_DELETE-abandoned resources in orphaned_resources
+    (type -> [id]); _delete_for_resetup reshapes them to type -> [{"Identifier": id}]
+    so reset can fold them into unresolved_orphans and fail closed.
+    """
+    with patch.object(
+        restorer._cleanup_mgr, "cleanup_stack", new_callable=AsyncMock
+    ) as mock_cleanup:
+        cleanup_result = MagicMock()
+        cleanup_result.all_stacks_succeeded = True
+        cleanup_result.orphaned_resources = {
+            "AWS::EC2::InternetGateway": ["igw-abandoned"],
+        }
+        mock_cleanup.return_value = cleanup_result
+
+        result = asyncio.run(restorer._delete_for_resetup("test-stack"))
+
+    assert result.outcome is RestoreOutcome.DELETED_NEEDS_REDEPLOY
+    assert result.abandoned == {
+        "AWS::EC2::InternetGateway": [{"Identifier": "igw-abandoned"}],
+    }
 
 
 @mock_aws
@@ -461,7 +490,7 @@ def test_delete_for_resetup_returns_failed_when_deletion_fails(restorer):
 
         result = asyncio.run(restorer._delete_for_resetup("test-stack"))
 
-    assert result is RestoreOutcome.FAILED
+    assert result.outcome is RestoreOutcome.FAILED
 
 
 @mock_aws
@@ -475,7 +504,7 @@ def test_delete_for_resetup_handles_exception(restorer):
     ):
         result = asyncio.run(restorer._delete_for_resetup("test-stack"))
 
-    assert result is RestoreOutcome.FAILED
+    assert result.outcome is RestoreOutcome.FAILED
 
 
 @mock_aws
@@ -486,7 +515,7 @@ def test_delete_for_resetup_already_gone_is_success(restorer):
     stack no longer exists (e.g. a ROLLBACK_COMPLETE/empty stack removed before
     or during reset). The goal of delete_for_resetup is for the stack to be
     absent so setup recreates it — already-absent satisfies that, so it must
-    return DELETED_NEEDS_REDEPLOY rather than FAILED (which fails the reset).
+    return DELETED_NEEDS_REDEPLOY (nothing abandoned) rather than FAILED.
     """
     with patch.object(
         restorer._cleanup_mgr,
@@ -496,7 +525,8 @@ def test_delete_for_resetup_already_gone_is_success(restorer):
     ):
         result = asyncio.run(restorer._delete_for_resetup("test-stack"))
 
-    assert result is RestoreOutcome.DELETED_NEEDS_REDEPLOY
+    assert result.outcome is RestoreOutcome.DELETED_NEEDS_REDEPLOY
+    assert result.abandoned == {}
 
 
 # ===========================================================================

--- a/tests/resource_management/snapshot/test_snapshot_manager.py
+++ b/tests/resource_management/snapshot/test_snapshot_manager.py
@@ -806,6 +806,63 @@ def test_snapshot_account_writes_local_file_and_skips_s3(temp_snapshot_dir, mock
 
 
 # ===========================================================================
+# snapshot_account — forbidden-identifier guard (defense-in-depth)
+# ===========================================================================
+
+
+@mock_aws
+def test_snapshot_account_refuses_baseline_with_forbidden_identifier(temp_snapshot_dir, mocker):
+    """A captured baseline containing a flagged orphan is refused, never saved."""
+    manager = create_test_manager()
+
+    captured = _region_snapshot("us-east-1", stack="stack-e1", resource_id="vpc-orphan")
+    mocker.patch.object(manager, "capture_snapshot_multiregion", return_value=captured)
+    save_spy = mocker.patch.object(manager, "save_snapshot")
+
+    ctx = SnapshotContext(
+        scenario_id="my-scenario",
+        scenario_hash="hash1",
+        regions=["us-east-1"],
+        stage=SnapshotStage.POST_SETUP,
+        account_ids=["123456789012"],
+        forbidden_identifiers={"vpc-orphan"},
+    )
+
+    session = boto3.Session(region_name="us-east-1")
+    result = manager.snapshot_account(session, "123456789012", ctx)
+
+    assert result.success is False
+    assert result.error_message is not None
+    assert "vpc-orphan" in result.error_message
+    save_spy.assert_not_called()
+
+
+@mock_aws
+def test_snapshot_account_saves_when_forbidden_identifiers_absent(temp_snapshot_dir, mocker):
+    """A non-intersecting (or empty) forbidden set does not block the normal save."""
+    manager = create_test_manager()
+
+    captured = _region_snapshot("us-east-1", stack="stack-e1", resource_id="role-e1")
+    mocker.patch.object(manager, "capture_snapshot_multiregion", return_value=captured)
+    save_spy = mocker.patch.object(manager, "save_snapshot")
+
+    ctx = SnapshotContext(
+        scenario_id="my-scenario",
+        scenario_hash="hash1",
+        regions=["us-east-1"],
+        stage=SnapshotStage.POST_SETUP,
+        account_ids=["123456789012"],
+        forbidden_identifiers={"vpc-not-present"},
+    )
+
+    session = boto3.Session(region_name="us-east-1")
+    result = manager.snapshot_account(session, "123456789012", ctx)
+
+    assert result.success is True
+    save_spy.assert_called_once()
+
+
+# ===========================================================================
 # Fresh-account subscription retry — _list_active_stacks self-heals OptInRequired
 #
 # _list_active_stacks is the snapshot's first CloudFormation call, so it is the

--- a/tests/resource_management/verify/test_verify_manager.py
+++ b/tests/resource_management/verify/test_verify_manager.py
@@ -958,6 +958,111 @@ def test_verify_account_state_skip_early_false_all_pass(
 
 
 # ===========================================================================
+# _check_new_resources — fail closed on an unenumerable baseline type
+# ===========================================================================
+
+
+@mock_aws
+@patch("aws_bench.resource_management.verify.manager.make_scanner")
+def test_check_new_resources_fails_closed_on_unenumerable_baseline_type(mock_scanner_class):
+    """A baseline-tracked type still in scan_result.failed fails verify closed.
+
+    The scanner already retries transient errors, so a persistent failure on a type
+    that mattered at setup could hide a leaked resource forever if silently skipped.
+    """
+    from aws_bench.resource_management.ccapi.models import ScanResult
+
+    session = boto3.Session(region_name="us-east-1")
+
+    mock_scanner = MagicMock()
+    mock_scanner.scan_resources.return_value = ScanResult(
+        detected={}, failed={"AWS::EC2::InternetGateway": "throttled"}
+    )
+    mock_scanner_class.return_value = mock_scanner
+
+    manager = VerifyManager(session)
+    result = manager._check_new_resources(
+        baseline_resource_ids={"AWS::EC2::InternetGateway": [{"Identifier": "igw-1"}]},
+        baseline_failed={},
+        baseline_empty=set(),
+    )
+
+    assert result is not None
+    assert result.success is False
+    assert "Could not enumerate 1 baseline resource type(s)" in result.reason
+    assert isinstance(result.details, dict)
+    assert result.details["unenumerable_types"] == ["AWS::EC2::InternetGateway"]
+
+
+@mock_aws
+@patch("aws_bench.resource_management.verify.manager.make_scanner")
+def test_check_new_resources_ignores_failed_type_absent_from_baseline(mock_scanner_class):
+    """A failed type that was NOT in the baseline does not fail verify.
+
+    The fail-closed rule is scoped to baseline-tracked types; a newly-discovered
+    type failing to enumerate is not a leaked-baseline-resource risk.
+    """
+    from aws_bench.resource_management.ccapi.models import ScanResult
+
+    session = boto3.Session(region_name="us-east-1")
+
+    mock_scanner = MagicMock()
+    # The failed type is absent from the baseline (baseline only tracks S3 buckets).
+    mock_scanner.scan_resources.return_value = ScanResult(
+        detected={}, failed={"AWS::EC2::InternetGateway": "throttled"}
+    )
+    mock_scanner_class.return_value = mock_scanner
+
+    manager = VerifyManager(session)
+    result = manager._check_new_resources(
+        baseline_resource_ids={"AWS::S3::Bucket": [{"Identifier": "b1"}]},
+        baseline_failed={},
+        baseline_empty=set(),
+    )
+
+    # No unenumerable baseline type and no new resources -> clean.
+    assert result is None
+
+
+# ===========================================================================
+# find_orphan_resources — reset's orphan/scan-health census wrapper
+# ===========================================================================
+
+
+@mock_aws
+@patch("aws_bench.resource_management.verify.manager.make_scanner")
+def test_find_orphan_resources_flags_orphan_from_snapshot(mock_scanner_class):
+    """The wrapper runs only the new-resource census and surfaces a orphan."""
+    from aws_bench.resource_management.ccapi.models import ScanResult
+
+    session = boto3.Session(region_name="us-east-1")
+
+    mock_scanner = MagicMock()
+    mock_scanner.scan_resources.return_value = ScanResult(
+        detected={"AWS::S3::Bucket": [{"Identifier": "orphan-bucket"}]}, failed={}
+    )
+    mock_scanner_class.return_value = mock_scanner
+
+    snapshot = Snapshot(
+        timestamp=datetime.now(timezone.utc),
+        account_id="123456789012",
+        environment_id="test-env",
+        scenario_hash="v1.0",
+        drift_baseline={},
+        stack_metadata={},
+        resource_ids={"AWS::S3::Bucket": []},
+        empty_resource_types={"AWS::S3::Bucket"},
+    )
+
+    result = VerifyManager(session).find_orphan_resources(snapshot)
+
+    assert result is not None
+    assert result.success is False
+    assert result.new_resources is not None
+    assert "AWS::S3::Bucket" in result.new_resources
+
+
+# ===========================================================================
 # _check_dataset_version — scenario hash comparison
 # ===========================================================================
 

--- a/tests/scenario/test_trial.py
+++ b/tests/scenario/test_trial.py
@@ -482,6 +482,119 @@ def test_reset_redeploy_not_blocked_by_own_contamination(tmp_path, fake_containe
     acct.clear_contaminated.assert_awaited_once_with("111")
 
 
+# -- baseline recapture is gated on a fully-clean reset -------------------
+
+
+def test_baseline_recapture_allowed_only_when_all_clean():
+    """Recapture is allowed only when every result is success and orphan-free."""
+    clean = ResetResult(success=True, reason="ok", account_id="111")
+    orphan = ResetResult(
+        success=False,
+        reason="orphan",
+        account_id="222",
+        unresolved_orphans={"AWS::EC2::Vpc": [{"Identifier": "vpc-1"}]},
+    )
+    failed = ResetResult(success=False, reason="drift", account_id="333")
+
+    assert ScenarioTrial._baseline_recapture_allowed([clean]) is True
+    assert ScenarioTrial._baseline_recapture_allowed([clean, orphan]) is False
+    assert ScenarioTrial._baseline_recapture_allowed([clean, failed]) is False
+    # A success=True result still blocks recapture if it carries orphans.
+    still_orphan = ResetResult(
+        success=True,
+        reason="ok",
+        account_id="444",
+        unresolved_orphans={"AWS::EC2::Vpc": [{"Identifier": "vpc-2"}]},
+    )
+    assert ScenarioTrial._baseline_recapture_allowed([still_orphan]) is False
+
+
+def test_orphan_identifiers_unions_across_results():
+    """The orphan-id union pulls Identifier from every result's orphans."""
+    a = ResetResult(
+        success=False,
+        reason="x",
+        account_id="111",
+        unresolved_orphans={"AWS::EC2::Vpc": [{"Identifier": "vpc-1"}]},
+    )
+    b = ResetResult(
+        success=False,
+        reason="y",
+        account_id="222",
+        unresolved_orphans={
+            "AWS::EC2::Vpc": [{"Identifier": "vpc-2"}],
+            "AWS::S3::Bucket": [{"Identifier": "b-1"}, {"NoId": "skip"}],
+        },
+    )
+    clean = ResetResult(success=True, reason="ok", account_id="333")
+    assert ScenarioTrial._orphan_identifiers([a, b, clean]) == {"vpc-1", "vpc-2", "b-1"}
+    assert ScenarioTrial._orphan_identifiers([clean]) == set()
+
+
+def test_run_reset_skips_recapture_when_an_account_has_orphans(
+    tmp_path, fake_container, fake_creds
+):
+    """A orphan-carrying account blocks the scenario-wide baseline recapture.
+
+    One account needs_redeploy (stack deleted), another carries unresolved
+    orphans (success=False). Recapture would absorb the live orphan, so
+    _run_snapshot must not run and the trial fails with ResetFailedError.
+    """
+    trial = _build_trial(tmp_path, fake_container, fake_creds)
+    acct = MagicMock()
+    acct.mark_contaminated = AsyncMock()
+    acct.clear_contaminated = AsyncMock()
+    trial._account_manager = acct
+
+    redeploy = ResetResult(
+        success=True, reason="stack deleted", needs_redeploy=True, account_id="111"
+    )
+    orphan = ResetResult(
+        success=False,
+        reason="orphan",
+        account_id="222",
+        unresolved_orphans={"AWS::EC2::Vpc": [{"Identifier": "vpc-1"}]},
+    )
+    with (
+        patch(
+            "aws_bench.resource_management.manager.ResourceManager.reset_scenarios",
+            new_callable=AsyncMock,
+            return_value=[redeploy, orphan],
+        ),
+        patch.object(trial, "_redeploy_with_retry", new_callable=AsyncMock),
+        patch.object(trial, "_run_snapshot", new_callable=AsyncMock) as snap,
+    ):
+        with pytest.raises(ResetFailedError):
+            asyncio.run(trial._run_reset())
+
+    snap.assert_not_awaited()
+
+
+def test_run_reset_recaptures_when_all_clean(tmp_path, fake_container, fake_creds):
+    """A clean reset with a needs_redeploy account recaptures the baseline once."""
+    trial = _build_trial(tmp_path, fake_container, fake_creds)
+    acct = MagicMock()
+    acct.mark_contaminated = AsyncMock()
+    acct.clear_contaminated = AsyncMock()
+    trial._account_manager = acct
+
+    redeploy = ResetResult(
+        success=True, reason="stack deleted", needs_redeploy=True, account_id="111"
+    )
+    with (
+        patch(
+            "aws_bench.resource_management.manager.ResourceManager.reset_scenarios",
+            new_callable=AsyncMock,
+            return_value=[redeploy],
+        ),
+        patch.object(trial, "_redeploy_with_retry", new_callable=AsyncMock),
+        patch.object(trial, "_run_snapshot", new_callable=AsyncMock) as snap,
+    ):
+        asyncio.run(trial._run_reset())  # no raise
+
+    snap.assert_awaited_once()
+
+
 def test_run_passes_account_tag_into_phase_env(tmp_path, fake_container, fake_creds):
     trial = _build_trial(tmp_path, fake_container, fake_creds)
     asyncio.run(trial.run(ScenarioPhase.DEPLOY))


### PR DESCRIPTION
## Summary

Fix a critical class of bugs where leaked/orphaned AWS resources could be silently absorbed into the baseline snapshot, making them permanently invisible to the reset/cleanup system.

This is Nithin's change that I tested locally and rebased

## The Bug

1. Reset's verify census correctly flags an IGW as a new resource on a non-default scenario VPC
2. Cleanup tries to delete it, but `DetachInternetGateway` fails: `DependencyViolation` — a NAT gateway / Elastic IP is still mapped
3. The code logs "verification will catch it" — but reset then deletes a stack for rebuild, which triggers a "skip final verify" rule (region-wide). The leftover IGW is never re-checked.
4. After rebuild, reset re-captures the account snapshot as the new baseline. The orphan is still present, so it gets **absorbed into the baseline** — making it invisible to all future runs.

## The Fix (4 commits)

### 1. `fix(reset): fail-closed verify so a deleted stack cannot suppress orphan/scan re-checks`
A deleted-for-rebuild stack no longer suppresses the existence re-check of other resources that reset failed to delete. If a leftover survives, the reset fails loudly.

### 2. `fix(cleanup): surface force-abandoned resources as orphans instead of a write-only manifest note`
Resources that are force-abandoned during stack deletion now flow through the full result chain (StackDeletionResult → CleanupSummary → ResetResult) instead of being hidden in manifest-only notes.

### 3. `fix(reset): never recapture the baseline over a live orphan or failed reset`
Defense-in-depth: `SnapshotContext.forbidden_identifiers` prevents saving a baseline containing known orphans regardless of caller behavior. If reset fails, baseline is NOT recaptured.

### 4. `fix(cleanup): dependency-ordered IGW/NAT/EIP teardown to clear the mapped-address wedge`
Implements correct teardown ordering: NAT Gateway → Elastic IP → Internet Gateway. Previously, attempting to detach an IGW while a NAT/EIP was still mapped caused `DependencyViolation` and permanent orphan.

## Testing

### Unit Tests
- **2,891 tests pass**, all lint/format/typecheck clean
- `ruff check`: ✅ All checks passed
- `ruff format`: ✅ 362 files already formatted  
- `pyright`: ✅ 0 errors, 0 warnings

### E2E: Reset Orphan Handling (Fresh Environment)

```
Environment: reset-orphan-test
Account:     251426272559
Scenario:    ec2-multiregion
```

| Step | Result |
|------|--------|
| `aws-bench env init` | ✅ Account provisioned, init snapshot taken |
| `aws-bench env setup` | ✅ ec2-multiregion deployed (3 regions) |
| Manually created orphan IGW + orphan IAM role | ✅ Simulates leaked resources |
| `aws-bench env reset` | ✅ **FAILED loudly** (`ResetFailedError`) — correct! |
| Orphan IGW cleaned during sweep | ✅ Deleted by cleanup handlers |
| Baseline NOT recaptured over orphans | ✅ No post-reset snapshot saved |
| Original baseline preserved | ✅ `pre-setup` and `post-setup` snapshots intact |

**Key verification**: Before this fix, reset would succeed and absorb the orphan into the baseline (invisible forever). After this fix, reset fails with `ResetFailedError` and the baseline is protected.

## Diff Stats

```
23 files changed, 1806 insertions(+), 463 deletions(-)
```

## Origin

Ported from internal staging repo branch `reset-leftover-baseline-absorption` by Nithin Kamal. Rebased onto public `main` (1 commit auto-dropped — already upstream). All 4 remaining commits applied cleanly with no conflicts.