### PR TITLE
chore(registry): bump datasets to main HEAD

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1,97 +1,97 @@
 [
   {
     "name": "api-and-observability",
-    "version": "0.7.1",
+    "version": "0.7.2",
     "description": "Multi-service environment with OpenSearch, ECS, Lambda, API Gateway, CloudFront, Redshift, Step Functions, Bedrock, and ELBv2 across us-east-1, us-west-2, and ap-southeast-1; 15 aws-introspection tasks against api-and-observability.",
     "tasks": [
       {
         "name": "bedrock-agentcore-runtime-missing-logs",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/api-and-observability/bedrock-agentcore-runtime-missing-logs"
       },
       {
         "name": "bedrock-kb-embedding-model-cfn-deps",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/api-and-observability/bedrock-kb-embedding-model-cfn-deps"
       },
       {
         "name": "cloudfront-distribution-origin-error-diagnosis",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/api-and-observability/cloudfront-distribution-origin-error-diagnosis"
       },
       {
         "name": "cloudfront-oac-s-forbidden-troubleshoot",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/api-and-observability/cloudfront-oac-s-forbidden-troubleshoot"
       },
       {
         "name": "debug-api-gateway-iam-authorization",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/api-and-observability/debug-api-gateway-iam-authorization"
       },
       {
         "name": "debug-websocket-api-backend-response",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/api-and-observability/debug-websocket-api-backend-response"
       },
       {
         "name": "diagnose-alb-five-xx-errors",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/api-and-observability/diagnose-alb-five-xx-errors"
       },
       {
         "name": "diagnose-alb-opensearch-bad-gateway",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/api-and-observability/diagnose-alb-opensearch-bad-gateway"
       },
       {
         "name": "diagnose-cloudwatch-alarm-firing",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/api-and-observability/diagnose-cloudwatch-alarm-firing"
       },
       {
         "name": "diagnose-onyx-lambda-processing-failure",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/api-and-observability/diagnose-onyx-lambda-processing-failure"
       },
       {
         "name": "diagnose-xray-service-latency-cause",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/api-and-observability/diagnose-xray-service-latency-cause"
       },
       {
         "name": "find-missing-step-functions-state-machine",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/api-and-observability/find-missing-step-functions-state-machine"
       },
       {
         "name": "lambda-sqs-reconciliation-no-output",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/api-and-observability/lambda-sqs-reconciliation-no-output"
       },
       {
         "name": "opensearch-check-document-request-status-logs",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/api-and-observability/opensearch-check-document-request-status-logs"
       },
       {
         "name": "opensearch-cognito-alb-timeout-diagnosis",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/api-and-observability/opensearch-cognito-alb-timeout-diagnosis"
       }
     ],
@@ -128,169 +128,169 @@
   },
   {
     "name": "compute-and-data",
-    "version": "0.7.0",
+    "version": "0.7.1",
     "description": "Mutation scenario (compute-and-data) \u2014 multi-region: us-east-1 (primary deployments), us-east-2 (Image Builder distribution), ap-southeast-1 (EMR cluster creation); 27 aws-introspection tasks against compute-and-data.",
     "tasks": [
       {
         "name": "amplify-deploy-frontend-from-s3",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/amplify-deploy-frontend-from-s3"
       },
       {
         "name": "analyze-b2b-commerce-summary-and-lifecycle",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/analyze-b2b-commerce-summary-and-lifecycle"
       },
       {
         "name": "appstream-stack-with-streaming-vpce",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "eab9b3934989ead214e7a5f790ff712024ad2a67",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/appstream-stack-with-streaming-vpce"
       },
       {
         "name": "athena-table-cloudfront-logs",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/athena-table-cloudfront-logs"
       },
       {
         "name": "create-athena-tables-from-s3",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/create-athena-tables-from-s3"
       },
       {
         "name": "create-dynamodb-tables-from-csv",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/create-dynamodb-tables-from-csv"
       },
       {
         "name": "create-eks-cluster",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/create-eks-cluster"
       },
       {
         "name": "create-emr-cluster-multi-master",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/create-emr-cluster-multi-master"
       },
       {
         "name": "create-medialive-channel",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "eab9b3934989ead214e7a5f790ff712024ad2a67",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/create-medialive-channel"
       },
       {
         "name": "create-s3-bucket-with-config",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "eab9b3934989ead214e7a5f790ff712024ad2a67",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/create-s3-bucket-with-config"
       },
       {
         "name": "create-s3-tables-with-compaction",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "eab9b3934989ead214e7a5f790ff712024ad2a67",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/create-s3-tables-with-compaction"
       },
       {
         "name": "create-vpc-valkey-dynamodb",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "eab9b3934989ead214e7a5f790ff712024ad2a67",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/create-vpc-valkey-dynamodb"
       },
       {
         "name": "deploy-ec2-instance-with-ebs",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/deploy-ec2-instance-with-ebs"
       },
       {
         "name": "dynamodb-strip-ec2-fields-from-prod",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/dynamodb-strip-ec2-fields-from-prod"
       },
       {
         "name": "ec2-image-builder-pipeline",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/ec2-image-builder-pipeline"
       },
       {
         "name": "expand-elasticsearch-cfn-template",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/expand-elasticsearch-cfn-template"
       },
       {
         "name": "install-efs-csi-fips",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/install-efs-csi-fips"
       },
       {
         "name": "invalidate-cloudfront-cache",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/invalidate-cloudfront-cache"
       },
       {
         "name": "ipam-pool-and-vpc",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/ipam-pool-and-vpc"
       },
       {
         "name": "kinesis-flink-studio-realtime",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/kinesis-flink-studio-realtime"
       },
       {
         "name": "lambda-versioned-alias-update",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/lambda-versioned-alias-update"
       },
       {
         "name": "manage-buckets-eks-sagemaker",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/manage-buckets-eks-sagemaker"
       },
       {
         "name": "managed-ad-with-ldaps-and-resets",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "eab9b3934989ead214e7a5f790ff712024ad2a67",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/managed-ad-with-ldaps-and-resets"
       },
       {
         "name": "move-s3-contents-and-cleanup",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/move-s3-contents-and-cleanup"
       },
       {
         "name": "move-s3-contents-within-bucket",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/move-s3-contents-within-bucket"
       },
       {
         "name": "serverless-stripe-api-with-stream",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/serverless-stripe-api-with-stream"
       },
       {
         "name": "sync-s3-buckets-with-metadata",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/sync-s3-buckets-with-metadata"
       }
     ],
@@ -298,7 +298,7 @@
       {
         "name": "compute-and-data",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "3a1661a070eb25649ec8e5bc987a210e324469d5",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "scenarios/compute-and-data"
       }
     ],
@@ -327,187 +327,187 @@
   },
   {
     "name": "databases-and-storage",
-    "version": "0.7.0",
+    "version": "0.7.1",
     "description": "Multi-service environment with Athena, CodeBuild, DynamoDB, EC2, ECS, Route53, S3, SQS, SSM, and WAF stacks across us-east-1 and us-west-2; 30 aws-introspection tasks against databases-and-storage.",
     "tasks": [
       {
         "name": "analyze-s-intelligent-tiering-configs",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/analyze-s-intelligent-tiering-configs"
       },
       {
         "name": "check-codebuild-project-nodejs-version",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/check-codebuild-project-nodejs-version"
       },
       {
         "name": "check-s-bucket-access-profiles",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/check-s-bucket-access-profiles"
       },
       {
         "name": "check-s-vector-bucket-indexes-exist",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/check-s-vector-bucket-indexes-exist"
       },
       {
         "name": "cloudformation-top-stacks-resource-breakdown",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/cloudformation-top-stacks-resource-breakdown"
       },
       {
         "name": "compare-s-bucket-structure-sizes",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/compare-s-bucket-structure-sizes"
       },
       {
         "name": "count-cfn-stacks-with-s-buckets",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/count-cfn-stacks-with-s-buckets"
       },
       {
         "name": "count-old-s-buckets",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/count-old-s-buckets"
       },
       {
         "name": "count-sns-topic-sqs-subscribers",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/count-sns-topic-sqs-subscribers"
       },
       {
         "name": "count-windows-server-managed-nodes",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/count-windows-server-managed-nodes"
       },
       {
         "name": "dynamodb-query-workflow-status-analysis",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/dynamodb-query-workflow-status-analysis"
       },
       {
         "name": "dynamodb-scan-and-fetch-record",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/dynamodb-scan-and-fetch-record"
       },
       {
         "name": "dynamodb-scan-filter-by-attribute",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/dynamodb-scan-filter-by-attribute"
       },
       {
         "name": "dynamodb-tables-resource-based-policy",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/dynamodb-tables-resource-based-policy"
       },
       {
         "name": "estimate-ec-running-instance-costs",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/estimate-ec-running-instance-costs"
       },
       {
         "name": "get-s-bucket-ownership-controls",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/get-s-bucket-ownership-controls"
       },
       {
         "name": "glue-database-tables-schema-details",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "aafc9db61a67c30f42043d07472d4b933abca965",
         "path": "tasks/databases-and-storage/glue-database-tables-schema-details"
       },
       {
         "name": "investigate-athena-table-creation-origin",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/investigate-athena-table-creation-origin"
       },
       {
         "name": "list-buckets-with-lifecycle-policy",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/list-buckets-with-lifecycle-policy"
       },
       {
         "name": "list-dynamodb-kinesis-streams-all-regions",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/list-dynamodb-kinesis-streams-all-regions"
       },
       {
         "name": "list-dynamodb-tables-all-regions",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/list-dynamodb-tables-all-regions"
       },
       {
         "name": "list-s-bucket-subdirectories",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/list-s-bucket-subdirectories"
       },
       {
         "name": "list-waf-webacl-findings",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/list-waf-webacl-findings"
       },
       {
         "name": "query-dynamodb-filtered-records-count",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/query-dynamodb-filtered-records-count"
       },
       {
         "name": "report-unencrypted-s-buckets",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/report-unencrypted-s-buckets"
       },
       {
         "name": "retrieve-s-csv-object-contents",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/retrieve-s-csv-object-contents"
       },
       {
         "name": "retrieve-s-text-file-contents",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/retrieve-s-text-file-contents"
       },
       {
         "name": "s-download-csv-identify-columns",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/s-download-csv-identify-columns"
       },
       {
         "name": "s-object-versions-and-metadata",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/s-object-versions-and-metadata"
       },
       {
         "name": "scan-dynamodb-table-by-status",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/scan-dynamodb-table-by-status"
       }
     ],
@@ -515,7 +515,7 @@
       {
         "name": "databases-and-storage",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "3a1661a070eb25649ec8e5bc987a210e324469d5",
+        "git_commit_id": "aafc9db61a67c30f42043d07472d4b933abca965",
         "path": "scenarios/databases-and-storage"
       }
     ],
@@ -544,61 +544,61 @@
   },
   {
     "name": "ec2-multiregion",
-    "version": "0.7.0",
+    "version": "0.7.1",
     "description": "Small EC2-only environment used for end-to-end env-setup validation. Two stacks (ec2_ks84v1fh1, ec2_ls9fuhb52) plus QARolesStack across us-east-1, us-west-1, and us-west-2; 9 aws-introspection tasks against ec2-multiregion.",
     "tasks": [
       {
         "name": "describe-cloudformation-stack-resources",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/ec2-multiregion/describe-cloudformation-stack-resources"
       },
       {
         "name": "describe-ec-instances-cross-region-connectivity",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/ec2-multiregion/describe-ec-instances-cross-region-connectivity"
       },
       {
         "name": "ec-instances-without-default-vpc",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/ec2-multiregion/ec-instances-without-default-vpc"
       },
       {
         "name": "find-ec-instances-in-public-subnets",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/ec2-multiregion/find-ec-instances-in-public-subnets"
       },
       {
         "name": "list-ec-instances-all-regions",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/ec2-multiregion/list-ec-instances-all-regions"
       },
       {
         "name": "list-ec-instances-all-regions-1",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/ec2-multiregion/list-ec-instances-all-regions-1"
       },
       {
         "name": "list-ec-instances-by-vpc-across-regions",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/ec2-multiregion/list-ec-instances-by-vpc-across-regions"
       },
       {
         "name": "list-ec-private-ips-all-regions",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/ec2-multiregion/list-ec-private-ips-all-regions"
       },
       {
         "name": "list-unused-security-groups-all-regions",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/ec2-multiregion/list-unused-security-groups-all-regions"
       }
     ],
@@ -635,73 +635,73 @@
   },
   {
     "name": "reference-architectures",
-    "version": "0.7.0",
+    "version": "0.7.1",
     "description": "Multi-service environment with ALB, API Gateway, AppSync, Backup, Batch, CloudFormation, CloudFront, CloudWatch, CodePipeline, Cognito, DynamoDB, EC2, ECS, EventBridge, Glue, ImageBuilder, Lambda, Lex, MQ, RDS, Rekognition, Route53, S3, Service Catalog, SSM, Step Functions, Transfer Family, and WAF stacks in us-east-1; 11 aws-introspection tasks against reference-architectures.",
     "tasks": [
       {
         "name": "analyze-stepfunctions-job-poller-loop",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "aafc9db61a67c30f42043d07472d4b933abca965",
         "path": "tasks/reference-architectures/analyze-stepfunctions-job-poller-loop"
       },
       {
         "name": "audit-cognito-account-recovery",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/reference-architectures/audit-cognito-account-recovery"
       },
       {
         "name": "diagnose-batch-job-no-logs",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/reference-architectures/diagnose-batch-job-no-logs"
       },
       {
         "name": "diagnose-glue-pipeline-not-running",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/reference-architectures/diagnose-glue-pipeline-not-running"
       },
       {
         "name": "diagnose-rabbitmq-consumer-failure",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/reference-architectures/diagnose-rabbitmq-consumer-failure"
       },
       {
         "name": "diagnose-rekognition-reupload-stale",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/reference-architectures/diagnose-rekognition-reupload-stale"
       },
       {
         "name": "diagnose-s3-event-notification-break",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/reference-architectures/diagnose-s3-event-notification-break"
       },
       {
         "name": "diagnose-sftp-alarm-not-firing",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/reference-architectures/diagnose-sftp-alarm-not-firing"
       },
       {
         "name": "review-aurora-production-readiness",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/reference-architectures/review-aurora-production-readiness"
       },
       {
         "name": "review-backup-plan-cross-region",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/reference-architectures/review-backup-plan-cross-region"
       },
       {
         "name": "trace-ec2-ssh-access-path",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/reference-architectures/trace-ec2-ssh-access-path"
       }
     ],
@@ -738,85 +738,85 @@
   },
   {
     "name": "serverless-apps",
-    "version": "0.7.0",
+    "version": "0.7.1",
     "description": "Complex multi-service environment: VPC, ALB, RDS, MSK, ECS, DocumentDB, Lambda, S3, SNS, Firehose. Single stack across us-east-1; 13 aws-introspection tasks against serverless-apps.",
     "tasks": [
       {
         "name": "check-lambda-layers-s-code",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/serverless-apps/check-lambda-layers-s-code"
       },
       {
         "name": "check-s-buckets-public-access",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/serverless-apps/check-s-buckets-public-access"
       },
       {
         "name": "check-s-lifecycle-tag-filter-rules",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/serverless-apps/check-s-lifecycle-tag-filter-rules"
       },
       {
         "name": "ecs-services-custom-configurations-check",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/serverless-apps/ecs-services-custom-configurations-check"
       },
       {
         "name": "ecs-services-ecr-access-check",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/serverless-apps/ecs-services-ecr-access-check"
       },
       {
         "name": "find-lambda-functions-tagged-blueprint",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/serverless-apps/find-lambda-functions-tagged-blueprint"
       },
       {
         "name": "find-metric-streams-excluding-namespace",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/serverless-apps/find-metric-streams-excluding-namespace"
       },
       {
         "name": "find-sns-triggered-lambda-functions",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/serverless-apps/find-sns-triggered-lambda-functions"
       },
       {
         "name": "list-s-buckets-website-hosting",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/serverless-apps/list-s-buckets-website-hosting"
       },
       {
         "name": "list-s-buckets-with-metrics-tag-filters",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/serverless-apps/list-s-buckets-with-metrics-tag-filters"
       },
       {
         "name": "list-s-cross-account-analytics-exports",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/serverless-apps/list-s-cross-account-analytics-exports"
       },
       {
         "name": "list-s-inventory-configs-with-prefix",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/serverless-apps/list-s-inventory-configs-with-prefix"
       },
       {
         "name": "s-bucket-metrics-tag-filter-check",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/serverless-apps/s-bucket-metrics-tag-filter-check"
       }
     ],
@@ -853,55 +853,55 @@
   },
   {
     "name": "streaming-and-iot",
-    "version": "0.7.0",
+    "version": "0.7.1",
     "description": "Multi-service environment for niche-service mutation tasks: Connect Customer Profiles, S3, IoT, EventBridge, ECS-on-EC2, Kinesis Data Streams, RDS+S3-Tables, MSK, Neptune. 9 stacks in us-east-1; 8 aws-introspection tasks against streaming-and-iot.",
     "tasks": [
       {
         "name": "connect-create-customer-profiles",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/streaming-and-iot/connect-create-customer-profiles"
       },
       {
         "name": "ecs-on-ec2-with-cloudmap",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/streaming-and-iot/ecs-on-ec2-with-cloudmap"
       },
       {
         "name": "health-eventbridge-csv-export",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/streaming-and-iot/health-eventbridge-csv-export"
       },
       {
         "name": "iot-thing-restrict-vpce-ipv4",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/streaming-and-iot/iot-thing-restrict-vpce-ipv4"
       },
       {
         "name": "iotsitewise-windfarm-rollup-models",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "eab9b3934989ead214e7a5f790ff712024ad2a67",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/streaming-and-iot/iotsitewise-windfarm-rollup-models"
       },
       {
         "name": "kds-firehose-iceberg-athena",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/streaming-and-iot/kds-firehose-iceberg-athena"
       },
       {
         "name": "neptune-bulk-load-and-shortest-path",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/streaming-and-iot/neptune-bulk-load-and-shortest-path"
       },
       {
         "name": "s3-csv-to-xlsx-lambda-pipeline",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/streaming-and-iot/s3-csv-to-xlsx-lambda-pipeline"
       }
     ],
@@ -909,7 +909,7 @@
       {
         "name": "streaming-and-iot",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "3a1661a070eb25649ec8e5bc987a210e324469d5",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "scenarios/streaming-and-iot"
       }
     ],
@@ -938,133 +938,133 @@
   },
   {
     "name": "troubleshooting-multiservice",
-    "version": "0.7.0",
+    "version": "0.7.1",
     "description": "30 stacks across 7 regions exercising EC2/ECS/ECR/Glue/Lambda/CFN/RDS/Redshift/SageMaker. Includes setup scripts that build & push Docker images to ECR, mutate KMS key policies, trigger expected Glue/SFN states, and intentionally drive one CFN stack into UPDATE_FAILED for a troubleshooting task; 21 aws-introspection tasks against troubleshooting-multiservice.",
     "tasks": [
       {
         "name": "asg-instance-health-check-failure",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/troubleshooting-multiservice/asg-instance-health-check-failure"
       },
       {
         "name": "asg-secondary-network-interface-attach-failure",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/troubleshooting-multiservice/asg-secondary-network-interface-attach-failure"
       },
       {
         "name": "check-vpc-flow-log-destinations",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/troubleshooting-multiservice/check-vpc-flow-log-destinations"
       },
       {
         "name": "diagnose-asg-instance-issues",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/troubleshooting-multiservice/diagnose-asg-instance-issues"
       },
       {
         "name": "diagnose-auto-scaling-group-launch-failure",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/troubleshooting-multiservice/diagnose-auto-scaling-group-launch-failure"
       },
       {
         "name": "diagnose-ecs-cluster-no-traffic",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/troubleshooting-multiservice/diagnose-ecs-cluster-no-traffic"
       },
       {
         "name": "diagnose-ecs-service-no-running-tasks-1",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/troubleshooting-multiservice/diagnose-ecs-service-no-running-tasks-1"
       },
       {
         "name": "diagnose-emr-cluster-performance-issues",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "aafc9db61a67c30f42043d07472d4b933abca965",
         "path": "tasks/troubleshooting-multiservice/diagnose-emr-cluster-performance-issues"
       },
       {
         "name": "diagnose-redshift-cluster-health-issues",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/troubleshooting-multiservice/diagnose-redshift-cluster-health-issues"
       },
       {
         "name": "diagnose-step-functions-failing-executions",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/troubleshooting-multiservice/diagnose-step-functions-failing-executions"
       },
       {
         "name": "ec-instance-security-vulnerability-scan",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/troubleshooting-multiservice/ec-instance-security-vulnerability-scan"
       },
       {
         "name": "ec-secrets-manager-exit-code-error",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/troubleshooting-multiservice/ec-secrets-manager-exit-code-error"
       },
       {
         "name": "ecs-elasticache-transit-gateway-connectivity",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/troubleshooting-multiservice/ecs-elasticache-transit-gateway-connectivity"
       },
       {
         "name": "ecs-service-deployment-failure-diagnosis",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/troubleshooting-multiservice/ecs-service-deployment-failure-diagnosis"
       },
       {
         "name": "eventbridge-ecs-task-trigger-debugging",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/troubleshooting-multiservice/eventbridge-ecs-task-trigger-debugging"
       },
       {
         "name": "fix-cloudformation-update-failed-stack",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "aafc9db61a67c30f42043d07472d4b933abca965",
         "path": "tasks/troubleshooting-multiservice/fix-cloudformation-update-failed-stack"
       },
       {
         "name": "glue-job-wrong-deployment-region",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/troubleshooting-multiservice/glue-job-wrong-deployment-region"
       },
       {
         "name": "lambda-appconfig-stale-value-troubleshoot",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/troubleshooting-multiservice/lambda-appconfig-stale-value-troubleshoot"
       },
       {
         "name": "troubleshoot-asg-ssh-connectivity",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/troubleshooting-multiservice/troubleshoot-asg-ssh-connectivity"
       },
       {
         "name": "troubleshoot-glue-job-table-read-failure",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/troubleshooting-multiservice/troubleshoot-glue-job-table-read-failure"
       },
       {
         "name": "verify-ec-traffic-routes-through-network-firewall",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/troubleshooting-multiservice/verify-ec-traffic-routes-through-network-firewall"
       }
     ],
@@ -1101,61 +1101,61 @@
   },
   {
     "name": "aws-bench-quickstart",
-    "version": "0.7.0",
+    "version": "0.7.1",
     "description": "Test dataset to try out aws-bench and run a smoke test to confirm that the framework is configured correctly. It uses the same tasks as the ec2-multiregion scenario.",
     "tasks": [
       {
         "name": "describe-cloudformation-stack-resources",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/ec2-multiregion/describe-cloudformation-stack-resources"
       },
       {
         "name": "describe-ec-instances-cross-region-connectivity",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/ec2-multiregion/describe-ec-instances-cross-region-connectivity"
       },
       {
         "name": "ec-instances-without-default-vpc",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/ec2-multiregion/ec-instances-without-default-vpc"
       },
       {
         "name": "find-ec-instances-in-public-subnets",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/ec2-multiregion/find-ec-instances-in-public-subnets"
       },
       {
         "name": "list-ec-instances-all-regions",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/ec2-multiregion/list-ec-instances-all-regions"
       },
       {
         "name": "list-ec-instances-all-regions-1",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/ec2-multiregion/list-ec-instances-all-regions-1"
       },
       {
         "name": "list-ec-instances-by-vpc-across-regions",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/ec2-multiregion/list-ec-instances-by-vpc-across-regions"
       },
       {
         "name": "list-ec-private-ips-all-regions",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/ec2-multiregion/list-ec-private-ips-all-regions"
       },
       {
         "name": "list-unused-security-groups-all-regions",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/ec2-multiregion/list-unused-security-groups-all-regions"
       }
     ],
@@ -1192,289 +1192,289 @@
   },
   {
     "name": "aws-bench-advanced",
-    "version": "0.7.1",
+    "version": "0.7.2",
     "description": "Hard-tier launch dataset (phase 1): 47 introspection tasks across reference-architectures, api-and-observability, and troubleshooting-multiservice.",
     "tasks": [
       {
         "name": "analyze-stepfunctions-job-poller-loop",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "aafc9db61a67c30f42043d07472d4b933abca965",
         "path": "tasks/reference-architectures/analyze-stepfunctions-job-poller-loop"
       },
       {
         "name": "audit-cognito-account-recovery",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/reference-architectures/audit-cognito-account-recovery"
       },
       {
         "name": "diagnose-batch-job-no-logs",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/reference-architectures/diagnose-batch-job-no-logs"
       },
       {
         "name": "diagnose-glue-pipeline-not-running",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/reference-architectures/diagnose-glue-pipeline-not-running"
       },
       {
         "name": "diagnose-rekognition-reupload-stale",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/reference-architectures/diagnose-rekognition-reupload-stale"
       },
       {
         "name": "review-backup-plan-cross-region",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/reference-architectures/review-backup-plan-cross-region"
       },
       {
         "name": "diagnose-rabbitmq-consumer-failure",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/reference-architectures/diagnose-rabbitmq-consumer-failure"
       },
       {
         "name": "diagnose-sftp-alarm-not-firing",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/reference-architectures/diagnose-sftp-alarm-not-firing"
       },
       {
         "name": "trace-ec2-ssh-access-path",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/reference-architectures/trace-ec2-ssh-access-path"
       },
       {
         "name": "review-aurora-production-readiness",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/reference-architectures/review-aurora-production-readiness"
       },
       {
         "name": "diagnose-s3-event-notification-break",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/reference-architectures/diagnose-s3-event-notification-break"
       },
       {
         "name": "bedrock-kb-embedding-model-cfn-deps",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/api-and-observability/bedrock-kb-embedding-model-cfn-deps"
       },
       {
         "name": "debug-websocket-api-backend-response",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/api-and-observability/debug-websocket-api-backend-response"
       },
       {
         "name": "opensearch-check-document-request-status-logs",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/api-and-observability/opensearch-check-document-request-status-logs"
       },
       {
         "name": "bedrock-agentcore-runtime-missing-logs",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/api-and-observability/bedrock-agentcore-runtime-missing-logs"
       },
       {
         "name": "cloudfront-oac-s-forbidden-troubleshoot",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/api-and-observability/cloudfront-oac-s-forbidden-troubleshoot"
       },
       {
         "name": "diagnose-alb-five-xx-errors",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/api-and-observability/diagnose-alb-five-xx-errors"
       },
       {
         "name": "diagnose-cloudwatch-alarm-firing",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/api-and-observability/diagnose-cloudwatch-alarm-firing"
       },
       {
         "name": "diagnose-onyx-lambda-processing-failure",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/api-and-observability/diagnose-onyx-lambda-processing-failure"
       },
       {
         "name": "opensearch-cognito-alb-timeout-diagnosis",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/api-and-observability/opensearch-cognito-alb-timeout-diagnosis"
       },
       {
         "name": "find-missing-step-functions-state-machine",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/api-and-observability/find-missing-step-functions-state-machine"
       },
       {
         "name": "diagnose-xray-service-latency-cause",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/api-and-observability/diagnose-xray-service-latency-cause"
       },
       {
         "name": "lambda-sqs-reconciliation-no-output",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/api-and-observability/lambda-sqs-reconciliation-no-output"
       },
       {
         "name": "cloudfront-distribution-origin-error-diagnosis",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/api-and-observability/cloudfront-distribution-origin-error-diagnosis"
       },
       {
         "name": "debug-api-gateway-iam-authorization",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/api-and-observability/debug-api-gateway-iam-authorization"
       },
       {
         "name": "diagnose-alb-opensearch-bad-gateway",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/api-and-observability/diagnose-alb-opensearch-bad-gateway"
       },
       {
         "name": "asg-secondary-network-interface-attach-failure",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/troubleshooting-multiservice/asg-secondary-network-interface-attach-failure"
       },
       {
         "name": "diagnose-asg-instance-issues",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/troubleshooting-multiservice/diagnose-asg-instance-issues"
       },
       {
         "name": "diagnose-ecs-cluster-no-traffic",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/troubleshooting-multiservice/diagnose-ecs-cluster-no-traffic"
       },
       {
         "name": "troubleshoot-asg-ssh-connectivity",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/troubleshooting-multiservice/troubleshoot-asg-ssh-connectivity"
       },
       {
         "name": "check-vpc-flow-log-destinations",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/troubleshooting-multiservice/check-vpc-flow-log-destinations"
       },
       {
         "name": "ecs-service-deployment-failure-diagnosis",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/troubleshooting-multiservice/ecs-service-deployment-failure-diagnosis"
       },
       {
         "name": "eventbridge-ecs-task-trigger-debugging",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/troubleshooting-multiservice/eventbridge-ecs-task-trigger-debugging"
       },
       {
         "name": "asg-instance-health-check-failure",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/troubleshooting-multiservice/asg-instance-health-check-failure"
       },
       {
         "name": "diagnose-ecs-service-no-running-tasks-1",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/troubleshooting-multiservice/diagnose-ecs-service-no-running-tasks-1"
       },
       {
         "name": "diagnose-redshift-cluster-health-issues",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/troubleshooting-multiservice/diagnose-redshift-cluster-health-issues"
       },
       {
         "name": "ec-instance-security-vulnerability-scan",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/troubleshooting-multiservice/ec-instance-security-vulnerability-scan"
       },
       {
         "name": "ec-secrets-manager-exit-code-error",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/troubleshooting-multiservice/ec-secrets-manager-exit-code-error"
       },
       {
         "name": "fix-cloudformation-update-failed-stack",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "aafc9db61a67c30f42043d07472d4b933abca965",
         "path": "tasks/troubleshooting-multiservice/fix-cloudformation-update-failed-stack"
       },
       {
         "name": "glue-job-wrong-deployment-region",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/troubleshooting-multiservice/glue-job-wrong-deployment-region"
       },
       {
         "name": "troubleshoot-glue-job-table-read-failure",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/troubleshooting-multiservice/troubleshoot-glue-job-table-read-failure"
       },
       {
         "name": "ecs-elasticache-transit-gateway-connectivity",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/troubleshooting-multiservice/ecs-elasticache-transit-gateway-connectivity"
       },
       {
         "name": "lambda-appconfig-stale-value-troubleshoot",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/troubleshooting-multiservice/lambda-appconfig-stale-value-troubleshoot"
       },
       {
         "name": "verify-ec-traffic-routes-through-network-firewall",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/troubleshooting-multiservice/verify-ec-traffic-routes-through-network-firewall"
       },
       {
         "name": "diagnose-emr-cluster-performance-issues",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "aafc9db61a67c30f42043d07472d4b933abca965",
         "path": "tasks/troubleshooting-multiservice/diagnose-emr-cluster-performance-issues"
       },
       {
         "name": "diagnose-auto-scaling-group-launch-failure",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/troubleshooting-multiservice/diagnose-auto-scaling-group-launch-failure"
       },
       {
         "name": "diagnose-step-functions-failing-executions",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/troubleshooting-multiservice/diagnose-step-functions-failing-executions"
       }
     ],
@@ -1523,475 +1523,475 @@
   },
   {
     "name": "aws-bench-basic",
-    "version": "0.7.0",
+    "version": "0.7.1",
     "description": "Easy-tier launch dataset (phase 1): 78 introspection and mutation tasks across streaming-and-iot, compute-and-data, serverless-apps, and databases-and-storage.",
     "tasks": [
       {
         "name": "connect-create-customer-profiles",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/streaming-and-iot/connect-create-customer-profiles"
       },
       {
         "name": "ecs-on-ec2-with-cloudmap",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/streaming-and-iot/ecs-on-ec2-with-cloudmap"
       },
       {
         "name": "health-eventbridge-csv-export",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/streaming-and-iot/health-eventbridge-csv-export"
       },
       {
         "name": "iot-thing-restrict-vpce-ipv4",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/streaming-and-iot/iot-thing-restrict-vpce-ipv4"
       },
       {
         "name": "iotsitewise-windfarm-rollup-models",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "eab9b3934989ead214e7a5f790ff712024ad2a67",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/streaming-and-iot/iotsitewise-windfarm-rollup-models"
       },
       {
         "name": "kds-firehose-iceberg-athena",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/streaming-and-iot/kds-firehose-iceberg-athena"
       },
       {
         "name": "neptune-bulk-load-and-shortest-path",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/streaming-and-iot/neptune-bulk-load-and-shortest-path"
       },
       {
         "name": "s3-csv-to-xlsx-lambda-pipeline",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/streaming-and-iot/s3-csv-to-xlsx-lambda-pipeline"
       },
       {
         "name": "amplify-deploy-frontend-from-s3",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/amplify-deploy-frontend-from-s3"
       },
       {
         "name": "analyze-b2b-commerce-summary-and-lifecycle",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/analyze-b2b-commerce-summary-and-lifecycle"
       },
       {
         "name": "appstream-stack-with-streaming-vpce",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "eab9b3934989ead214e7a5f790ff712024ad2a67",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/appstream-stack-with-streaming-vpce"
       },
       {
         "name": "athena-table-cloudfront-logs",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/athena-table-cloudfront-logs"
       },
       {
         "name": "create-athena-tables-from-s3",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/create-athena-tables-from-s3"
       },
       {
         "name": "create-dynamodb-tables-from-csv",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/create-dynamodb-tables-from-csv"
       },
       {
         "name": "create-eks-cluster",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/create-eks-cluster"
       },
       {
         "name": "create-emr-cluster-multi-master",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/create-emr-cluster-multi-master"
       },
       {
         "name": "create-medialive-channel",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "eab9b3934989ead214e7a5f790ff712024ad2a67",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/create-medialive-channel"
       },
       {
         "name": "create-s3-bucket-with-config",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "eab9b3934989ead214e7a5f790ff712024ad2a67",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/create-s3-bucket-with-config"
       },
       {
         "name": "create-s3-tables-with-compaction",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "eab9b3934989ead214e7a5f790ff712024ad2a67",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/create-s3-tables-with-compaction"
       },
       {
         "name": "create-vpc-valkey-dynamodb",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "eab9b3934989ead214e7a5f790ff712024ad2a67",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/create-vpc-valkey-dynamodb"
       },
       {
         "name": "deploy-ec2-instance-with-ebs",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/deploy-ec2-instance-with-ebs"
       },
       {
         "name": "dynamodb-strip-ec2-fields-from-prod",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/dynamodb-strip-ec2-fields-from-prod"
       },
       {
         "name": "ec2-image-builder-pipeline",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/ec2-image-builder-pipeline"
       },
       {
         "name": "expand-elasticsearch-cfn-template",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/expand-elasticsearch-cfn-template"
       },
       {
         "name": "install-efs-csi-fips",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/install-efs-csi-fips"
       },
       {
         "name": "invalidate-cloudfront-cache",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/invalidate-cloudfront-cache"
       },
       {
         "name": "ipam-pool-and-vpc",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/ipam-pool-and-vpc"
       },
       {
         "name": "kinesis-flink-studio-realtime",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/kinesis-flink-studio-realtime"
       },
       {
         "name": "lambda-versioned-alias-update",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/lambda-versioned-alias-update"
       },
       {
         "name": "manage-buckets-eks-sagemaker",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/manage-buckets-eks-sagemaker"
       },
       {
         "name": "managed-ad-with-ldaps-and-resets",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "eab9b3934989ead214e7a5f790ff712024ad2a67",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/managed-ad-with-ldaps-and-resets"
       },
       {
         "name": "move-s3-contents-and-cleanup",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/move-s3-contents-and-cleanup"
       },
       {
         "name": "move-s3-contents-within-bucket",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/move-s3-contents-within-bucket"
       },
       {
         "name": "serverless-stripe-api-with-stream",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/serverless-stripe-api-with-stream"
       },
       {
         "name": "sync-s3-buckets-with-metadata",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/sync-s3-buckets-with-metadata"
       },
       {
         "name": "check-lambda-layers-s-code",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/serverless-apps/check-lambda-layers-s-code"
       },
       {
         "name": "check-s-buckets-public-access",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/serverless-apps/check-s-buckets-public-access"
       },
       {
         "name": "check-s-lifecycle-tag-filter-rules",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/serverless-apps/check-s-lifecycle-tag-filter-rules"
       },
       {
         "name": "ecs-services-custom-configurations-check",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/serverless-apps/ecs-services-custom-configurations-check"
       },
       {
         "name": "ecs-services-ecr-access-check",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/serverless-apps/ecs-services-ecr-access-check"
       },
       {
         "name": "find-lambda-functions-tagged-blueprint",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/serverless-apps/find-lambda-functions-tagged-blueprint"
       },
       {
         "name": "find-metric-streams-excluding-namespace",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/serverless-apps/find-metric-streams-excluding-namespace"
       },
       {
         "name": "find-sns-triggered-lambda-functions",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/serverless-apps/find-sns-triggered-lambda-functions"
       },
       {
         "name": "list-s-buckets-website-hosting",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/serverless-apps/list-s-buckets-website-hosting"
       },
       {
         "name": "list-s-buckets-with-metrics-tag-filters",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/serverless-apps/list-s-buckets-with-metrics-tag-filters"
       },
       {
         "name": "list-s-cross-account-analytics-exports",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/serverless-apps/list-s-cross-account-analytics-exports"
       },
       {
         "name": "list-s-inventory-configs-with-prefix",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/serverless-apps/list-s-inventory-configs-with-prefix"
       },
       {
         "name": "s-bucket-metrics-tag-filter-check",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/serverless-apps/s-bucket-metrics-tag-filter-check"
       },
       {
         "name": "analyze-s-intelligent-tiering-configs",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/analyze-s-intelligent-tiering-configs"
       },
       {
         "name": "check-codebuild-project-nodejs-version",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/check-codebuild-project-nodejs-version"
       },
       {
         "name": "check-s-bucket-access-profiles",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/check-s-bucket-access-profiles"
       },
       {
         "name": "check-s-vector-bucket-indexes-exist",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/check-s-vector-bucket-indexes-exist"
       },
       {
         "name": "cloudformation-top-stacks-resource-breakdown",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/cloudformation-top-stacks-resource-breakdown"
       },
       {
         "name": "compare-s-bucket-structure-sizes",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/compare-s-bucket-structure-sizes"
       },
       {
         "name": "count-cfn-stacks-with-s-buckets",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/count-cfn-stacks-with-s-buckets"
       },
       {
         "name": "count-old-s-buckets",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/count-old-s-buckets"
       },
       {
         "name": "count-sns-topic-sqs-subscribers",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/count-sns-topic-sqs-subscribers"
       },
       {
         "name": "count-windows-server-managed-nodes",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/count-windows-server-managed-nodes"
       },
       {
         "name": "dynamodb-query-workflow-status-analysis",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/dynamodb-query-workflow-status-analysis"
       },
       {
         "name": "dynamodb-scan-and-fetch-record",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/dynamodb-scan-and-fetch-record"
       },
       {
         "name": "dynamodb-scan-filter-by-attribute",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/dynamodb-scan-filter-by-attribute"
       },
       {
         "name": "dynamodb-tables-resource-based-policy",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/dynamodb-tables-resource-based-policy"
       },
       {
         "name": "estimate-ec-running-instance-costs",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/estimate-ec-running-instance-costs"
       },
       {
         "name": "get-s-bucket-ownership-controls",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/get-s-bucket-ownership-controls"
       },
       {
         "name": "glue-database-tables-schema-details",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "aafc9db61a67c30f42043d07472d4b933abca965",
         "path": "tasks/databases-and-storage/glue-database-tables-schema-details"
       },
       {
         "name": "investigate-athena-table-creation-origin",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/investigate-athena-table-creation-origin"
       },
       {
         "name": "list-buckets-with-lifecycle-policy",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/list-buckets-with-lifecycle-policy"
       },
       {
         "name": "list-dynamodb-kinesis-streams-all-regions",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/list-dynamodb-kinesis-streams-all-regions"
       },
       {
         "name": "list-dynamodb-tables-all-regions",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/list-dynamodb-tables-all-regions"
       },
       {
         "name": "list-s-bucket-subdirectories",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/list-s-bucket-subdirectories"
       },
       {
         "name": "list-waf-webacl-findings",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/list-waf-webacl-findings"
       },
       {
         "name": "query-dynamodb-filtered-records-count",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/query-dynamodb-filtered-records-count"
       },
       {
         "name": "report-unencrypted-s-buckets",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/report-unencrypted-s-buckets"
       },
       {
         "name": "retrieve-s-csv-object-contents",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/retrieve-s-csv-object-contents"
       },
       {
         "name": "retrieve-s-text-file-contents",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/retrieve-s-text-file-contents"
       },
       {
         "name": "s-download-csv-identify-columns",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/s-download-csv-identify-columns"
       },
       {
         "name": "s-object-versions-and-metadata",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/s-object-versions-and-metadata"
       },
       {
         "name": "scan-dynamodb-table-by-status",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/scan-dynamodb-table-by-status"
       }
     ],
@@ -1999,13 +1999,13 @@
       {
         "name": "streaming-and-iot",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "3a1661a070eb25649ec8e5bc987a210e324469d5",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "scenarios/streaming-and-iot"
       },
       {
         "name": "compute-and-data",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "3a1661a070eb25649ec8e5bc987a210e324469d5",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "scenarios/compute-and-data"
       },
       {
@@ -2017,7 +2017,7 @@
       {
         "name": "databases-and-storage",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "3a1661a070eb25649ec8e5bc987a210e324469d5",
+        "git_commit_id": "aafc9db61a67c30f42043d07472d4b933abca965",
         "path": "scenarios/databases-and-storage"
       }
     ],
@@ -2046,811 +2046,811 @@
   },
   {
     "name": "all",
-    "version": "0.7.1",
+    "version": "0.7.2",
     "description": "Unified dataset spanning 8 scenario(s) (api-and-observability, compute-and-data, databases-and-storage, ec2-multiregion, reference-architectures, serverless-apps, streaming-and-iot, troubleshooting-multiservice): 8 scenarios, 134 tasks.",
     "tasks": [
       {
         "name": "bedrock-agentcore-runtime-missing-logs",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/api-and-observability/bedrock-agentcore-runtime-missing-logs"
       },
       {
         "name": "bedrock-kb-embedding-model-cfn-deps",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/api-and-observability/bedrock-kb-embedding-model-cfn-deps"
       },
       {
         "name": "cloudfront-distribution-origin-error-diagnosis",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/api-and-observability/cloudfront-distribution-origin-error-diagnosis"
       },
       {
         "name": "cloudfront-oac-s-forbidden-troubleshoot",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/api-and-observability/cloudfront-oac-s-forbidden-troubleshoot"
       },
       {
         "name": "debug-api-gateway-iam-authorization",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/api-and-observability/debug-api-gateway-iam-authorization"
       },
       {
         "name": "debug-websocket-api-backend-response",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/api-and-observability/debug-websocket-api-backend-response"
       },
       {
         "name": "diagnose-alb-five-xx-errors",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/api-and-observability/diagnose-alb-five-xx-errors"
       },
       {
         "name": "diagnose-alb-opensearch-bad-gateway",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/api-and-observability/diagnose-alb-opensearch-bad-gateway"
       },
       {
         "name": "diagnose-cloudwatch-alarm-firing",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/api-and-observability/diagnose-cloudwatch-alarm-firing"
       },
       {
         "name": "diagnose-onyx-lambda-processing-failure",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/api-and-observability/diagnose-onyx-lambda-processing-failure"
       },
       {
         "name": "diagnose-xray-service-latency-cause",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/api-and-observability/diagnose-xray-service-latency-cause"
       },
       {
         "name": "find-missing-step-functions-state-machine",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/api-and-observability/find-missing-step-functions-state-machine"
       },
       {
         "name": "lambda-sqs-reconciliation-no-output",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/api-and-observability/lambda-sqs-reconciliation-no-output"
       },
       {
         "name": "opensearch-check-document-request-status-logs",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/api-and-observability/opensearch-check-document-request-status-logs"
       },
       {
         "name": "opensearch-cognito-alb-timeout-diagnosis",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/api-and-observability/opensearch-cognito-alb-timeout-diagnosis"
       },
       {
         "name": "amplify-deploy-frontend-from-s3",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/amplify-deploy-frontend-from-s3"
       },
       {
         "name": "analyze-b2b-commerce-summary-and-lifecycle",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/analyze-b2b-commerce-summary-and-lifecycle"
       },
       {
         "name": "appstream-stack-with-streaming-vpce",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "eab9b3934989ead214e7a5f790ff712024ad2a67",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/appstream-stack-with-streaming-vpce"
       },
       {
         "name": "athena-table-cloudfront-logs",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/athena-table-cloudfront-logs"
       },
       {
         "name": "create-athena-tables-from-s3",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/create-athena-tables-from-s3"
       },
       {
         "name": "create-dynamodb-tables-from-csv",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/create-dynamodb-tables-from-csv"
       },
       {
         "name": "create-eks-cluster",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/create-eks-cluster"
       },
       {
         "name": "create-emr-cluster-multi-master",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/create-emr-cluster-multi-master"
       },
       {
         "name": "create-medialive-channel",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "eab9b3934989ead214e7a5f790ff712024ad2a67",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/create-medialive-channel"
       },
       {
         "name": "create-s3-bucket-with-config",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "eab9b3934989ead214e7a5f790ff712024ad2a67",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/create-s3-bucket-with-config"
       },
       {
         "name": "create-s3-tables-with-compaction",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "eab9b3934989ead214e7a5f790ff712024ad2a67",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/create-s3-tables-with-compaction"
       },
       {
         "name": "create-vpc-valkey-dynamodb",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "eab9b3934989ead214e7a5f790ff712024ad2a67",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/create-vpc-valkey-dynamodb"
       },
       {
         "name": "deploy-ec2-instance-with-ebs",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/deploy-ec2-instance-with-ebs"
       },
       {
         "name": "dynamodb-strip-ec2-fields-from-prod",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/dynamodb-strip-ec2-fields-from-prod"
       },
       {
         "name": "ec2-image-builder-pipeline",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/ec2-image-builder-pipeline"
       },
       {
         "name": "expand-elasticsearch-cfn-template",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/expand-elasticsearch-cfn-template"
       },
       {
         "name": "install-efs-csi-fips",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/install-efs-csi-fips"
       },
       {
         "name": "invalidate-cloudfront-cache",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/invalidate-cloudfront-cache"
       },
       {
         "name": "ipam-pool-and-vpc",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/ipam-pool-and-vpc"
       },
       {
         "name": "kinesis-flink-studio-realtime",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/kinesis-flink-studio-realtime"
       },
       {
         "name": "lambda-versioned-alias-update",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/lambda-versioned-alias-update"
       },
       {
         "name": "manage-buckets-eks-sagemaker",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/manage-buckets-eks-sagemaker"
       },
       {
         "name": "managed-ad-with-ldaps-and-resets",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "eab9b3934989ead214e7a5f790ff712024ad2a67",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/managed-ad-with-ldaps-and-resets"
       },
       {
         "name": "move-s3-contents-and-cleanup",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/move-s3-contents-and-cleanup"
       },
       {
         "name": "move-s3-contents-within-bucket",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/move-s3-contents-within-bucket"
       },
       {
         "name": "serverless-stripe-api-with-stream",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/serverless-stripe-api-with-stream"
       },
       {
         "name": "sync-s3-buckets-with-metadata",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/compute-and-data/sync-s3-buckets-with-metadata"
       },
       {
         "name": "analyze-s-intelligent-tiering-configs",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/analyze-s-intelligent-tiering-configs"
       },
       {
         "name": "check-codebuild-project-nodejs-version",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/check-codebuild-project-nodejs-version"
       },
       {
         "name": "check-s-bucket-access-profiles",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/check-s-bucket-access-profiles"
       },
       {
         "name": "check-s-vector-bucket-indexes-exist",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/check-s-vector-bucket-indexes-exist"
       },
       {
         "name": "cloudformation-top-stacks-resource-breakdown",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/cloudformation-top-stacks-resource-breakdown"
       },
       {
         "name": "compare-s-bucket-structure-sizes",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/compare-s-bucket-structure-sizes"
       },
       {
         "name": "count-cfn-stacks-with-s-buckets",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/count-cfn-stacks-with-s-buckets"
       },
       {
         "name": "count-old-s-buckets",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/count-old-s-buckets"
       },
       {
         "name": "count-sns-topic-sqs-subscribers",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/count-sns-topic-sqs-subscribers"
       },
       {
         "name": "count-windows-server-managed-nodes",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/count-windows-server-managed-nodes"
       },
       {
         "name": "dynamodb-query-workflow-status-analysis",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/dynamodb-query-workflow-status-analysis"
       },
       {
         "name": "dynamodb-scan-and-fetch-record",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/dynamodb-scan-and-fetch-record"
       },
       {
         "name": "dynamodb-scan-filter-by-attribute",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/dynamodb-scan-filter-by-attribute"
       },
       {
         "name": "dynamodb-tables-resource-based-policy",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/dynamodb-tables-resource-based-policy"
       },
       {
         "name": "estimate-ec-running-instance-costs",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/estimate-ec-running-instance-costs"
       },
       {
         "name": "get-s-bucket-ownership-controls",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/get-s-bucket-ownership-controls"
       },
       {
         "name": "glue-database-tables-schema-details",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "aafc9db61a67c30f42043d07472d4b933abca965",
         "path": "tasks/databases-and-storage/glue-database-tables-schema-details"
       },
       {
         "name": "investigate-athena-table-creation-origin",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/investigate-athena-table-creation-origin"
       },
       {
         "name": "list-buckets-with-lifecycle-policy",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/list-buckets-with-lifecycle-policy"
       },
       {
         "name": "list-dynamodb-kinesis-streams-all-regions",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/list-dynamodb-kinesis-streams-all-regions"
       },
       {
         "name": "list-dynamodb-tables-all-regions",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/list-dynamodb-tables-all-regions"
       },
       {
         "name": "list-s-bucket-subdirectories",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/list-s-bucket-subdirectories"
       },
       {
         "name": "list-waf-webacl-findings",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/list-waf-webacl-findings"
       },
       {
         "name": "query-dynamodb-filtered-records-count",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/query-dynamodb-filtered-records-count"
       },
       {
         "name": "report-unencrypted-s-buckets",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/report-unencrypted-s-buckets"
       },
       {
         "name": "retrieve-s-csv-object-contents",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/retrieve-s-csv-object-contents"
       },
       {
         "name": "retrieve-s-text-file-contents",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/retrieve-s-text-file-contents"
       },
       {
         "name": "s-download-csv-identify-columns",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/s-download-csv-identify-columns"
       },
       {
         "name": "s-object-versions-and-metadata",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/s-object-versions-and-metadata"
       },
       {
         "name": "scan-dynamodb-table-by-status",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/databases-and-storage/scan-dynamodb-table-by-status"
       },
       {
         "name": "describe-cloudformation-stack-resources",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/ec2-multiregion/describe-cloudformation-stack-resources"
       },
       {
         "name": "describe-ec-instances-cross-region-connectivity",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/ec2-multiregion/describe-ec-instances-cross-region-connectivity"
       },
       {
         "name": "ec-instances-without-default-vpc",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/ec2-multiregion/ec-instances-without-default-vpc"
       },
       {
         "name": "find-ec-instances-in-public-subnets",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/ec2-multiregion/find-ec-instances-in-public-subnets"
       },
       {
         "name": "list-ec-instances-all-regions",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/ec2-multiregion/list-ec-instances-all-regions"
       },
       {
         "name": "list-ec-instances-all-regions-1",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/ec2-multiregion/list-ec-instances-all-regions-1"
       },
       {
         "name": "list-ec-instances-by-vpc-across-regions",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/ec2-multiregion/list-ec-instances-by-vpc-across-regions"
       },
       {
         "name": "list-ec-private-ips-all-regions",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/ec2-multiregion/list-ec-private-ips-all-regions"
       },
       {
         "name": "list-unused-security-groups-all-regions",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/ec2-multiregion/list-unused-security-groups-all-regions"
       },
       {
         "name": "analyze-stepfunctions-job-poller-loop",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "aafc9db61a67c30f42043d07472d4b933abca965",
         "path": "tasks/reference-architectures/analyze-stepfunctions-job-poller-loop"
       },
       {
         "name": "audit-cognito-account-recovery",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/reference-architectures/audit-cognito-account-recovery"
       },
       {
         "name": "diagnose-batch-job-no-logs",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/reference-architectures/diagnose-batch-job-no-logs"
       },
       {
         "name": "diagnose-glue-pipeline-not-running",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/reference-architectures/diagnose-glue-pipeline-not-running"
       },
       {
         "name": "diagnose-rabbitmq-consumer-failure",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/reference-architectures/diagnose-rabbitmq-consumer-failure"
       },
       {
         "name": "diagnose-rekognition-reupload-stale",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/reference-architectures/diagnose-rekognition-reupload-stale"
       },
       {
         "name": "diagnose-s3-event-notification-break",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/reference-architectures/diagnose-s3-event-notification-break"
       },
       {
         "name": "diagnose-sftp-alarm-not-firing",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/reference-architectures/diagnose-sftp-alarm-not-firing"
       },
       {
         "name": "review-aurora-production-readiness",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/reference-architectures/review-aurora-production-readiness"
       },
       {
         "name": "review-backup-plan-cross-region",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/reference-architectures/review-backup-plan-cross-region"
       },
       {
         "name": "trace-ec2-ssh-access-path",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/reference-architectures/trace-ec2-ssh-access-path"
       },
       {
         "name": "check-lambda-layers-s-code",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/serverless-apps/check-lambda-layers-s-code"
       },
       {
         "name": "check-s-buckets-public-access",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/serverless-apps/check-s-buckets-public-access"
       },
       {
         "name": "check-s-lifecycle-tag-filter-rules",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/serverless-apps/check-s-lifecycle-tag-filter-rules"
       },
       {
         "name": "ecs-services-custom-configurations-check",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/serverless-apps/ecs-services-custom-configurations-check"
       },
       {
         "name": "ecs-services-ecr-access-check",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/serverless-apps/ecs-services-ecr-access-check"
       },
       {
         "name": "find-lambda-functions-tagged-blueprint",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/serverless-apps/find-lambda-functions-tagged-blueprint"
       },
       {
         "name": "find-metric-streams-excluding-namespace",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/serverless-apps/find-metric-streams-excluding-namespace"
       },
       {
         "name": "find-sns-triggered-lambda-functions",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/serverless-apps/find-sns-triggered-lambda-functions"
       },
       {
         "name": "list-s-buckets-website-hosting",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/serverless-apps/list-s-buckets-website-hosting"
       },
       {
         "name": "list-s-buckets-with-metrics-tag-filters",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/serverless-apps/list-s-buckets-with-metrics-tag-filters"
       },
       {
         "name": "list-s-cross-account-analytics-exports",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/serverless-apps/list-s-cross-account-analytics-exports"
       },
       {
         "name": "list-s-inventory-configs-with-prefix",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/serverless-apps/list-s-inventory-configs-with-prefix"
       },
       {
         "name": "s-bucket-metrics-tag-filter-check",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/serverless-apps/s-bucket-metrics-tag-filter-check"
       },
       {
         "name": "connect-create-customer-profiles",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/streaming-and-iot/connect-create-customer-profiles"
       },
       {
         "name": "ecs-on-ec2-with-cloudmap",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/streaming-and-iot/ecs-on-ec2-with-cloudmap"
       },
       {
         "name": "health-eventbridge-csv-export",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/streaming-and-iot/health-eventbridge-csv-export"
       },
       {
         "name": "iot-thing-restrict-vpce-ipv4",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/streaming-and-iot/iot-thing-restrict-vpce-ipv4"
       },
       {
         "name": "iotsitewise-windfarm-rollup-models",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "eab9b3934989ead214e7a5f790ff712024ad2a67",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/streaming-and-iot/iotsitewise-windfarm-rollup-models"
       },
       {
         "name": "kds-firehose-iceberg-athena",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/streaming-and-iot/kds-firehose-iceberg-athena"
       },
       {
         "name": "neptune-bulk-load-and-shortest-path",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/streaming-and-iot/neptune-bulk-load-and-shortest-path"
       },
       {
         "name": "s3-csv-to-xlsx-lambda-pipeline",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "tasks/streaming-and-iot/s3-csv-to-xlsx-lambda-pipeline"
       },
       {
         "name": "asg-instance-health-check-failure",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/troubleshooting-multiservice/asg-instance-health-check-failure"
       },
       {
         "name": "asg-secondary-network-interface-attach-failure",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/troubleshooting-multiservice/asg-secondary-network-interface-attach-failure"
       },
       {
         "name": "check-vpc-flow-log-destinations",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/troubleshooting-multiservice/check-vpc-flow-log-destinations"
       },
       {
         "name": "diagnose-asg-instance-issues",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/troubleshooting-multiservice/diagnose-asg-instance-issues"
       },
       {
         "name": "diagnose-auto-scaling-group-launch-failure",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/troubleshooting-multiservice/diagnose-auto-scaling-group-launch-failure"
       },
       {
         "name": "diagnose-ecs-cluster-no-traffic",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/troubleshooting-multiservice/diagnose-ecs-cluster-no-traffic"
       },
       {
         "name": "diagnose-ecs-service-no-running-tasks-1",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/troubleshooting-multiservice/diagnose-ecs-service-no-running-tasks-1"
       },
       {
         "name": "diagnose-emr-cluster-performance-issues",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "aafc9db61a67c30f42043d07472d4b933abca965",
         "path": "tasks/troubleshooting-multiservice/diagnose-emr-cluster-performance-issues"
       },
       {
         "name": "diagnose-redshift-cluster-health-issues",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/troubleshooting-multiservice/diagnose-redshift-cluster-health-issues"
       },
       {
         "name": "diagnose-step-functions-failing-executions",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/troubleshooting-multiservice/diagnose-step-functions-failing-executions"
       },
       {
         "name": "ec-instance-security-vulnerability-scan",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/troubleshooting-multiservice/ec-instance-security-vulnerability-scan"
       },
       {
         "name": "ec-secrets-manager-exit-code-error",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/troubleshooting-multiservice/ec-secrets-manager-exit-code-error"
       },
       {
         "name": "ecs-elasticache-transit-gateway-connectivity",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/troubleshooting-multiservice/ecs-elasticache-transit-gateway-connectivity"
       },
       {
         "name": "ecs-service-deployment-failure-diagnosis",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/troubleshooting-multiservice/ecs-service-deployment-failure-diagnosis"
       },
       {
         "name": "eventbridge-ecs-task-trigger-debugging",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/troubleshooting-multiservice/eventbridge-ecs-task-trigger-debugging"
       },
       {
         "name": "fix-cloudformation-update-failed-stack",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "aafc9db61a67c30f42043d07472d4b933abca965",
         "path": "tasks/troubleshooting-multiservice/fix-cloudformation-update-failed-stack"
       },
       {
         "name": "glue-job-wrong-deployment-region",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/troubleshooting-multiservice/glue-job-wrong-deployment-region"
       },
       {
         "name": "lambda-appconfig-stale-value-troubleshoot",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/troubleshooting-multiservice/lambda-appconfig-stale-value-troubleshoot"
       },
       {
         "name": "troubleshoot-asg-ssh-connectivity",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/troubleshooting-multiservice/troubleshoot-asg-ssh-connectivity"
       },
       {
         "name": "troubleshoot-glue-job-table-read-failure",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/troubleshooting-multiservice/troubleshoot-glue-job-table-read-failure"
       },
       {
         "name": "verify-ec-traffic-routes-through-network-firewall",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "023e7485be29d0e239c81f08d95b0cf11d0802cb",
+        "git_commit_id": "96b101fa1de0890f94e9ec7aea38c7b64ed49136",
         "path": "tasks/troubleshooting-multiservice/verify-ec-traffic-routes-through-network-firewall"
       }
     ],
@@ -2864,13 +2864,13 @@
       {
         "name": "compute-and-data",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "3a1661a070eb25649ec8e5bc987a210e324469d5",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "scenarios/compute-and-data"
       },
       {
         "name": "databases-and-storage",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "3a1661a070eb25649ec8e5bc987a210e324469d5",
+        "git_commit_id": "aafc9db61a67c30f42043d07472d4b933abca965",
         "path": "scenarios/databases-and-storage"
       },
       {
@@ -2894,7 +2894,7 @@
       {
         "name": "streaming-and-iot",
         "git_url": "https://github.com/aws-bench/aws-bench-datasets.git",
-        "git_commit_id": "3a1661a070eb25649ec8e5bc987a210e324469d5",
+        "git_commit_id": "7214635d5616d6875d9dba19fb0f815155ca4fac",
         "path": "scenarios/streaming-and-iot"
       },
       {


### PR DESCRIPTION
Regenerates `registry.json` via `scripts/update_registry.py` against `aws-bench-datasets` `main` HEAD.

## Why
`main`'s registry had **not been bumped since launch** — the last update was #12 (2026-07-24), and it was pinned to the near-launch dataset import (`023e748`). Meanwhile the datasets repo moved ~3 weeks ahead. This catches `main` up so its phase-2 scheduled runs use current dataset content.

## What this pulls in
- **Oracle solutions** (#16, #19, #21, #26)
- **Verifier rewardkit retry** on transient Bedrock errors (#27)
- **Task ground-truth/config fixes** (#28-#31, merged to datasets `main` via #40):
  - `analyze-stepfunctions-job-poller-loop` — remove brittle execution-history claims
  - `glue-database-tables-schema-details` — explicit `tableType: 'EXTERNAL_TABLE'`
  - `fix-cloudformation-update-failed` — `continue-update-rollback` → `rollback-stack` (the old answer was invalid for an UPDATE_FAILED/DisableRollback stack)
  - `diagnose-emr-cluster-performance` — reframe as configuration-risk diagnosis

## Impact
Fixes false 0.0 rewards on `main`-pinned scheduled runs caused by the stale ground truth (e.g. the CFN task's judge penalized the correct `rollback-stack` answer against the outdated reference). Your 4 tasks pin to the merge commit `aafc9db`.

## Generation / validation
- Generated by `scripts/update_registry.py --datasets-path ../aws-bench-datasets --add-unified` (not hand-edited).
- `registry.json` is valid JSON: 12 datasets, 402 task pins, all resolving to `aws-bench-datasets` `main` commits.
- Datasets `make check` passed green on the merged content.
- Only `registry.json` changed.