### PR TITLE
fix(verify): tolerate region-unavailable listers that reject in-region calls

### DIFF
--- a/aws_bench/resource_management/fastscan/listers/region_policy.py
+++ b/aws_bench/resource_management/fastscan/listers/region_policy.py
@@ -8,7 +8,12 @@ the fail-loud gate) and still scanned in every other region. Op-level, so a work
 is never dropped. Pure data (ships in the Lambda closure).
 
 Each entry requires proof: a lone isolated call returns no success across retries in that region
-while succeeding elsewhere (rules out account-wide throttling and concurrency).
+while succeeding elsewhere (rules out account-wide throttling and concurrency). A resource type
+the AWS regional-availability catalog confirms is *not offered* in a region is also proof: its
+endpoint resolves but the API rejects the call (AccessDenied "not authorized ... in this region"
+/ "not authorized to invoke this API operation", NotAuthorizedException, InvalidParameterValue,
+or an empty-message AccessDenied), and a type absent from a region cannot hold an orphan there —
+so recording it ``empty`` preserves the fail-closed guarantee.
 """
 
 from __future__ import annotations
@@ -28,4 +33,29 @@ UNAVAILABLE_LISTER_REGIONS: dict[tuple[str, str], frozenset[str]] = {
     ("greengrassv2", "ListComponents"): frozenset({"us-west-1"}),
     ("greengrassv2", "ListCoreDevices"): frozenset({"us-west-1"}),
     ("greengrassv2", "ListDeployments"): frozenset({"us-west-1"}),
+    ("iotwireless", "ListPartnerAccounts"): frozenset({"us-west-2"}),
+    ("bedrock", "ListAutomatedReasoningPolicies"): frozenset({"ap-southeast-1", "us-west-1"}),
+    ("bedrock-agent", "list_flows"): frozenset({"us-west-1"}),
+    ("bedrock-agent", "list_prompts"): frozenset({"us-west-1"}),
+    ("bedrock-data-automation", "list_blueprints"): frozenset({"ap-southeast-1"}),
+    ("bedrock-data-automation", "list_data_automation_libraries"): frozenset(
+        {"ap-southeast-1", "us-east-2"}
+    ),
+    ("bedrock-data-automation", "list_data_automation_projects"): frozenset({"ap-southeast-1"}),
+    ("comprehend", "ListDocumentClassificationJobs"): frozenset({"us-west-1"}),
+    ("comprehend", "ListDocumentClassifiers"): frozenset({"us-west-1"}),
+    ("comprehend", "ListEntitiesDetectionJobs"): frozenset({"us-west-1"}),
+    ("comprehend", "ListSentimentDetectionJobs"): frozenset({"us-west-1"}),
+    ("connect", "ListTrafficDistributionGroups"): frozenset({"ap-southeast-1"}),
+    ("connectcampaigns", "ListCampaigns"): frozenset({"ap-southeast-1"}),
+    ("dax", "describe_parameter_groups"): frozenset({"ap-northeast-2"}),
+    ("finspace", "ListEnvironments"): frozenset({"ap-southeast-1"}),
+    ("glue", "DescribeIntegrations"): frozenset({"us-west-1"}),
+    ("glue", "list_integration_resource_properties"): frozenset({"us-west-1"}),
+    ("inspector2", "ListCodeSecurityIntegrations"): frozenset({"us-west-1"}),
+    ("inspector2", "ListCodeSecurityScanConfigurations"): frozenset({"us-west-1"}),
+    ("omics", "ListAnnotationStores"): frozenset({"us-east-2"}),
+    ("omics", "ListVariantStores"): frozenset({"us-east-2"}),
+    ("rekognition", "DescribeProjects"): frozenset({"us-west-1"}),
+    ("rekognition", "ListStreamProcessors"): frozenset({"ap-southeast-1", "us-west-1"}),
 }

--- a/tests/resource_management/verify/test_verify_manager.py
+++ b/tests/resource_management/verify/test_verify_manager.py
@@ -1114,6 +1114,7 @@ def test_check_new_resources_fails_closed_on_access_denied(mock_scanner_class):
     assert result is not None
     assert result.success is False
     assert "Could not enumerate 1 baseline resource type(s)" in result.reason
+    assert isinstance(result.details, dict)
     assert result.details["unenumerable_types"] == ["AWS::S3::Bucket"]
 
 
@@ -1147,6 +1148,7 @@ def test_check_new_resources_mixed_tolerates_region_unavailable_but_fails_on_gen
     assert result is not None
     assert result.success is False
     # Only the genuine (non-region-unavailable) failure is surfaced.
+    assert isinstance(result.details, dict)
     assert result.details["unenumerable_types"] == ["AWS::EC2::InternetGateway"]
 
 
@@ -1180,6 +1182,7 @@ def test_check_new_resources_type_with_baseline_resources_fails_closed_despite_r
 
     assert result is not None
     assert result.success is False
+    assert isinstance(result.details, dict)
     assert result.details["unenumerable_types"] == ["AWS::GameLift::ContainerFleet"]
 
 
@@ -1261,6 +1264,7 @@ def test_check_new_resources_fails_closed_when_type_unenumerable_in_all_regions(
     )
     assert result is not None
     assert result.success is False
+    assert isinstance(result.details, dict)
     assert result.details["unenumerable_types"] == ["AWS::Rekognition::StreamProcessor"]
 
 
@@ -1315,6 +1319,7 @@ def test_check_new_resources_type_with_resources_not_tolerated_even_if_enumerabl
     )
     assert result is not None
     assert result.success is False
+    assert isinstance(result.details, dict)
     assert result.details["unenumerable_types"] == ["AWS::Rekognition::StreamProcessor"]
 
 


### PR DESCRIPTION
### Description of changes:

Several resource types are not offered by AWS in some scenario regions. Their endpoints resolve but the in-region list/describe call is rejected, and because _is_region_unavailable matches only on error-code substrings and excludes AccessDenied, verify/reset flagged these "unenumerable" and failed closed, causing failures during `verify` of `env reset`and `env verify`.

Observed errors (reproduced per (service, op, region), confirmed against the AWS regional-availability catalog):

- iotwireless ListPartnerAccounts in us-west-2: AccessDeniedException: "You are not authorized to call this API in this region us-west-2"
- bedrock ListAutomatedReasoningPolicies in ap-southeast-1, us-west-1: AccessDeniedException: "Your account is not authorized to invoke this API operation."
- bedrock-data-automation list_blueprints / list_data_automation_projects / list_data_automation_libraries in ap-southeast-1, us-east-2: AccessDeniedException (empty message)
- bedrock-agent list_flows / list_prompts in us-west-1: InternalServerErrorException (Flow/Prompt not offered in us-west-1)
- comprehend ListDocumentClassificationJobs / ListDocumentClassifiers / ListEntitiesDetectionJobs / ListSentimentDetectionJobs in us-west-1: NotAuthorizedException (Comprehend isNotExpandingIn us-west-1)
- connect ListTrafficDistributionGroups in ap-southeast-1: AccessDeniedException (type not offered in ap-southeast-1)
- connectcampaigns ListCampaigns in ap-southeast-1: AccessDeniedException
- dax describe_parameter_groups in ap-northeast-2: InvalidParameterValueException: "Access Denied to API Version: DAX_V3" (region_skip already covers ap-northeast-3, not ap-northeast-2)
- finspace ListEnvironments in ap-southeast-1: AccessDeniedException
- glue DescribeIntegrations in us-west-1: AccessDeniedException; glue ListIntegrationResourceProperties @us-west-1: API "Not Found" in region
- inspector2 ListCodeSecurityIntegrations / ListCodeSecurityScanConfigurations in us-west-1: AccessDeniedException
- omics ListAnnotationStores / ListVariantStores in us-east-2: AccessDeniedException
- rekognition DescribeProjects in us-west-1, ListStreamProcessors in ap-southeast-1, us-west-1: AccessDeniedException

Add the affected (service, op) -> regions entries to UNAVAILABLE_LISTER_REGIONS so the scanner records them empty (never failed) in those regions and still scans them everywhere else. A type absent from a region cannot hold an orphan, so this preserves the fail-closed guarantee.





By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
