### PR TITLE
fix(verify): allowlist ListPartnerAccounts in more AccessDenied regions

### DIFF
--- a/aws_bench/resource_management/fastscan/listers/region_policy.py
+++ b/aws_bench/resource_management/fastscan/listers/region_policy.py
@@ -33,7 +33,9 @@ UNAVAILABLE_LISTER_REGIONS: dict[tuple[str, str], frozenset[str]] = {
     ("greengrassv2", "ListComponents"): frozenset({"us-west-1"}),
     ("greengrassv2", "ListCoreDevices"): frozenset({"us-west-1"}),
     ("greengrassv2", "ListDeployments"): frozenset({"us-west-1"}),
-    ("iotwireless", "ListPartnerAccounts"): frozenset({"us-west-2"}),
+    ("iotwireless", "ListPartnerAccounts"): frozenset(
+        {"ap-northeast-1", "ap-southeast-2", "eu-central-1", "eu-west-1", "us-west-2"}
+    ),
     ("bedrock", "ListAutomatedReasoningPolicies"): frozenset({"ap-southeast-1", "us-west-1"}),
     ("bedrock-agent", "list_flows"): frozenset({"us-west-1"}),
     ("bedrock-agent", "list_prompts"): frozenset({"us-west-1"}),


### PR DESCRIPTION
### Description of changes:

IoT Wireless ListPartnerAccounts is a us-east-1-only API (Sidewalk partner accounts); its endpoint resolves in other regions but the operation rejects with AccessDeniedException. Steady scheduled runs (troubleshooting-multiservice) tripped the reset-verify gate on this type in eu-west-1, eu-central-1, ap-northeast-1, and ap-southeast-2, which were not in UNAVAILABLE_LISTER_REGIONS (only us-west-2 was).

Add those four regions so the fast-scan records the lister empty there instead of failing closed. Together with the existing LISTER_REGION_SKIP entries this covers all standard scanned regions except us-east-1, where the API is available and the lister runs normally.




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
