### PR TITLE
fix(cleanup): treat the default MediaConvert queue as AWS-managed

### DIFF
--- a/aws_bench/resource_management/verify/comparators.py
+++ b/aws_bench/resource_management/verify/comparators.py
@@ -93,6 +93,12 @@ AWS_MANAGED_FILTERS: dict[str, Callable[[str, dict], bool]] = {
     "AWS::SMSVOICE::OptOutList": lambda id, _: id.endswith("opt-out-list/Default"),
     # AWS-created default EventBridge event bus (undeletable).
     "AWS::Events::EventBus": lambda id, _: id.endswith("event-bus/default"),
+    # AWS-created default MediaConvert queue. Created lazily by the service on first
+    # MediaConvert use (so it is absent from the pre-deploy init snapshot) and cannot be
+    # deleted, so the init-snapshot diff would otherwise flag it as a leaked orphan. The
+    # lister emits the ARN (…:queues/Default). On-demand queues a task creates carry a
+    # custom name and are NOT filtered.
+    "AWS::MediaConvert::Queue": lambda id, _: id.endswith("queues/Default"),
     # Service-managed secrets (e.g. a Redshift namespace's admin credentials) are
     # created and rotated BY the owning AWS service, which names them with a "!"
     # marker: ``redshift!…``, ``rds!…``, ``aws!…`` (ARN ``…:secret:redshift!…``).

--- a/tests/resource_management/verify/test_comparators.py
+++ b/tests/resource_management/verify/test_comparators.py
@@ -451,3 +451,11 @@ class TestPhase2AwsOwnedFilters:
         assert predicate("arn:aws:events:us-east-1:123456789012:event-bus/default", {})
         # A task-created custom bus carries its own name and is NOT filtered.
         assert not predicate("arn:aws:events:us-east-1:123456789012:event-bus/my-bus", {})
+
+    def test_default_mediaconvert_queue_filtered_custom_kept(self):
+        predicate = self._predicate("AWS::MediaConvert::Queue")
+        # The account's default MediaConvert queue is service-created (lazily) and undeletable —
+        # filtered (the lister emits the ARN …:queues/Default).
+        assert predicate("arn:aws:mediaconvert:us-east-1:123456789012:queues/Default", {})
+        # A task-created on-demand queue carries its own name and is NOT filtered.
+        assert not predicate("arn:aws:mediaconvert:us-east-1:123456789012:queues/my-queue", {})


### PR DESCRIPTION
### Description of changes:
The account-default MediaConvert queue (arn:...:queues/Default) is created lazily by the service on first use, so it is absent from the pre-deploy init snapshot and cannot be deleted. The post-cleanup orphan scan diffed it against the init snapshot and reported it as a leaked orphan, failing an otherwise-clean fresh run with CleanupFailedError (observed on streaming-and-iot).

Add AWS::MediaConvert::Queue to AWS_MANAGED_FILTERS so filter_aws_managed_resources excludes the reserved Default queue (matched by its ARN suffix, the form the fast-scan lister emits) from both the cleanup orphan scan and verify drift. On-demand queues a task creates carry a custom name and are unaffected.




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
