### PR TITLE
fix(cleanup): disable DynamoDB deletion protection before delete

### DIFF
--- a/aws_bench/resource_management/cleanup/handlers/__init__.py
+++ b/aws_bench/resource_management/cleanup/handlers/__init__.py
@@ -14,6 +14,7 @@ from aws_bench.resource_management.cleanup.handlers import (
     databases,  # noqa: F401
     directory_service,  # noqa: F401
     dms,  # noqa: F401
+    dynamodb,  # noqa: F401
     ec2_image,  # noqa: F401
     ecr,  # noqa: F401
     efs,  # noqa: F401

--- a/aws_bench/resource_management/cleanup/handlers/dynamodb.py
+++ b/aws_bench/resource_management/cleanup/handlers/dynamodb.py
@@ -1,0 +1,137 @@
+"""DynamoDB cleanup handlers.
+
+A table created with ``DeletionProtectionEnabled`` rejects DeleteTable with
+``ValidationException: Resource cannot be deleted as it is currently protected
+against deletion. Disable deletion protection first.`` — so the cleanup/reset
+sweep leaves it as an orphan forever and fails the run (observed on
+create-vpc-valkey-dynamodb, which enables deletion protection).
+
+The prepare hook disables deletion protection so the subsequent CCAPI delete
+succeeds; no custom delete handler is needed. The same physical table surfaces
+under two scanned types — ``AWS::DynamoDB::Table`` (ListTables) and, when it is a
+global table, ``AWS::DynamoDB::GlobalTable`` (ListGlobalTables) — and both
+identifiers are the table NAME, so the same prepare is registered for both.
+Deletion protection is a per-(regional-)table property; disabling it here in the
+region being swept makes that replica deletable, and deleting it dissolves the
+global table.
+"""
+
+from __future__ import annotations
+
+import boto3
+from botocore.exceptions import BotoCoreError, ClientError
+
+from aws_bench.logging.logger import get_logger
+from aws_bench.resource_management.ccapi.models import Resource
+from aws_bench.resource_management.cleanup.handler_registry import resource_handler
+from aws_bench.resource_management.cleanup.models import HandlerResult, HandlerStatus
+from aws_bench.resource_management.utils.polling import wait_until
+from aws_bench.utils.concurrent import build_client
+
+logger = get_logger(__name__)
+
+_TABLE_ACTIVE_TIMEOUT = 120
+_TABLE_ACTIVE_INTERVAL = 5
+
+
+def _table_deletable(client, table_name: str) -> bool:
+    """True once the table is ACTIVE with deletion protection disabled.
+
+    ``update_table`` puts the table in UPDATING briefly; DeleteTable rejects a
+    non-ACTIVE table, so wait for it to settle. A vanished table (already deleted)
+    counts as deletable — nothing left to protect.
+    """
+    try:
+        table = client.describe_table(TableName=table_name)["Table"]
+    except ClientError as e:
+        if e.response.get("Error", {}).get("Code", "") == "ResourceNotFoundException":
+            return True
+        logger.debug("Error checking table '%s': %s", table_name, e)
+        return False
+    return table.get("TableStatus") == "ACTIVE" and not table.get("DeletionProtectionEnabled")
+
+
+def _disable_deletion_protection(
+    session: boto3.Session, table_name: str, resource_type: str
+) -> HandlerResult:
+    """Disable deletion protection on ``table_name`` so it can be deleted."""
+    client = build_client(session, "dynamodb")
+    try:
+        table = client.describe_table(TableName=table_name)["Table"]
+    except ClientError as e:
+        if e.response.get("Error", {}).get("Code", "") == "ResourceNotFoundException":
+            return HandlerResult(
+                resource_id=table_name,
+                resource_type=resource_type,
+                action="prepare",
+                status=HandlerStatus.SKIPPED,
+                message="Table not found",
+            )
+        return HandlerResult(
+            resource_id=table_name,
+            resource_type=resource_type,
+            action="prepare",
+            status=HandlerStatus.FAILED,
+            message=f"Error describing table: {e}",
+        )
+    except BotoCoreError as e:
+        return HandlerResult(
+            resource_id=table_name,
+            resource_type=resource_type,
+            action="prepare",
+            status=HandlerStatus.FAILED,
+            message=f"Connection error: {e}",
+        )
+
+    if not table.get("DeletionProtectionEnabled"):
+        return HandlerResult(
+            resource_id=table_name,
+            resource_type=resource_type,
+            action="prepare",
+            status=HandlerStatus.SUCCESS,
+            message="Deletion protection already disabled",
+        )
+
+    try:
+        client.update_table(TableName=table_name, DeletionProtectionEnabled=False)
+    except (ClientError, BotoCoreError) as e:
+        return HandlerResult(
+            resource_id=table_name,
+            resource_type=resource_type,
+            action="prepare",
+            status=HandlerStatus.FAILED,
+            message=f"Failed to disable deletion protection: {e}",
+        )
+
+    if not wait_until(
+        lambda: _table_deletable(client, table_name),
+        timeout=_TABLE_ACTIVE_TIMEOUT,
+        interval=_TABLE_ACTIVE_INTERVAL,
+    ):
+        return HandlerResult(
+            resource_id=table_name,
+            resource_type=resource_type,
+            action="prepare",
+            status=HandlerStatus.FAILED,
+            message="Timed out waiting for table to become deletable",
+        )
+
+    return HandlerResult(
+        resource_id=table_name,
+        resource_type=resource_type,
+        action="prepare",
+        status=HandlerStatus.SUCCESS,
+        message="Deletion protection disabled",
+    )
+
+
+# The lister emits the table NAME for both types (ListTables → TableName,
+# ListGlobalTables → GlobalTableName), which is what describe_table/update_table want.
+@resource_handler("AWS::DynamoDB::Table", role="prepare")
+def _prepare_table(resource: Resource, session: boto3.Session) -> HandlerResult:
+    return _disable_deletion_protection(session, resource.identifier, resource.type)
+
+
+@resource_handler("AWS::DynamoDB::GlobalTable", role="prepare")
+def _prepare_global_table(resource: Resource, session: boto3.Session) -> HandlerResult:
+    return _disable_deletion_protection(session, resource.identifier, resource.type)

--- a/tests/resource_management/cleanup/test_handlers_dynamodb.py
+++ b/tests/resource_management/cleanup/test_handlers_dynamodb.py
@@ -1,0 +1,100 @@
+"""Tests for DynamoDB cleanup handlers."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from botocore.exceptions import ClientError
+
+from aws_bench.resource_management.ccapi.models import Resource
+from aws_bench.resource_management.cleanup.handlers.dynamodb import (
+    _disable_deletion_protection,
+    _prepare_global_table,
+    _prepare_table,
+)
+from aws_bench.resource_management.cleanup.models import HandlerStatus
+
+_NOT_FOUND = ClientError(
+    {"Error": {"Code": "ResourceNotFoundException", "Message": "not found"}}, "DescribeTable"
+)
+
+
+@pytest.fixture(autouse=True)
+def _fast_wait_until():
+    """Patch the poll so tests never sleep; default success."""
+    with patch(
+        "aws_bench.resource_management.cleanup.handlers.dynamodb.wait_until",
+        return_value=True,
+    ) as mock:
+        yield mock
+
+
+def _patch_client(client: MagicMock):
+    return patch(
+        "aws_bench.resource_management.cleanup.handlers.dynamodb.build_client",
+        return_value=client,
+    )
+
+
+def test_disable_deletion_protection_disables_and_succeeds():
+    client = MagicMock()
+    client.describe_table.return_value = {
+        "Table": {"TableStatus": "ACTIVE", "DeletionProtectionEnabled": True}
+    }
+    with _patch_client(client):
+        result = _disable_deletion_protection(MagicMock(), "t1", "AWS::DynamoDB::Table")
+    client.update_table.assert_called_once_with(TableName="t1", DeletionProtectionEnabled=False)
+    assert result.status == HandlerStatus.SUCCESS
+
+
+def test_disable_deletion_protection_noop_when_already_disabled():
+    client = MagicMock()
+    client.describe_table.return_value = {
+        "Table": {"TableStatus": "ACTIVE", "DeletionProtectionEnabled": False}
+    }
+    with _patch_client(client):
+        result = _disable_deletion_protection(MagicMock(), "t1", "AWS::DynamoDB::Table")
+    client.update_table.assert_not_called()
+    assert result.status == HandlerStatus.SUCCESS
+
+
+def test_disable_deletion_protection_skips_missing_table():
+    client = MagicMock()
+    client.describe_table.side_effect = _NOT_FOUND
+    with _patch_client(client):
+        result = _disable_deletion_protection(MagicMock(), "gone", "AWS::DynamoDB::Table")
+    client.update_table.assert_not_called()
+    assert result.status == HandlerStatus.SKIPPED
+
+
+def test_disable_deletion_protection_times_out(_fast_wait_until):
+    _fast_wait_until.return_value = False
+    client = MagicMock()
+    client.describe_table.return_value = {
+        "Table": {"TableStatus": "ACTIVE", "DeletionProtectionEnabled": True}
+    }
+    with _patch_client(client):
+        result = _disable_deletion_protection(MagicMock(), "t1", "AWS::DynamoDB::Table")
+    assert result.status == HandlerStatus.FAILED
+
+
+def test_prepare_handlers_pass_identifier_as_table_name():
+    client = MagicMock()
+    client.describe_table.return_value = {
+        "Table": {"TableStatus": "ACTIVE", "DeletionProtectionEnabled": True}
+    }
+    with _patch_client(client):
+        # both scanned types resolve to the same table NAME; both should disable protection
+        r_table = _prepare_table(
+            Resource(type="AWS::DynamoDB::Table", identifier="storage-app-objects"), MagicMock()
+        )
+        r_global = _prepare_global_table(
+            Resource(type="AWS::DynamoDB::GlobalTable", identifier="storage-app-objects"),
+            MagicMock(),
+        )
+    assert r_table.status == HandlerStatus.SUCCESS
+    assert r_global.status == HandlerStatus.SUCCESS
+    client.update_table.assert_called_with(
+        TableName="storage-app-objects", DeletionProtectionEnabled=False
+    )


### PR DESCRIPTION
### Description of changes:

A DynamoDB table created with DeletionProtectionEnabled rejects DeleteTable with "Resource cannot be deleted as it is currently protected against deletion. Disable deletion protection first", so the cleanup/reset sweep left it as a permanent orphan and failed the run (observed on `create-vpc-valkey-dynamodb`: agent created a table storage-app-objects with deletion protection enabled in us-east-1, failing a reset).

Add a prepare handler for AWS::DynamoDB::Table and AWS::DynamoDB::GlobalTable (the same physical table surfaces under both scanned types, both keyed by the table name) that disables deletion protection and waits for the table to return to ACTIVE, so the existing CCAPI delete then succeeds. Deletion protection is a per-regional-table property, so disabling it in the swept region makes that replica deletable and deleting it dissolves the global table. Tables without protection are a no-op; a missing table is skipped.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
