### PR TITLE
fix(reset): tolerate region-unavailable baseline types via cross-region corroboration

### DIFF
--- a/aws_bench/resource_management/reset/manager.py
+++ b/aws_bench/resource_management/reset/manager.py
@@ -12,7 +12,11 @@ from aws_bench.account_management.constants import ORG_ACCESS_ROLE
 from aws_bench.account_management.models import ScenarioAccount
 from aws_bench.logging.logger import get_logger, log_context
 from aws_bench.resource_management.ccapi.manager import CloudControlManager, Resource
-from aws_bench.resource_management.ccapi.models import GLOBAL_RESOURCE_TYPES, MAX_WORKERS_HEAVY
+from aws_bench.resource_management.ccapi.models import (
+    GLOBAL_RESOURCE_TYPES,
+    MAX_WORKERS_HEAVY,
+    ScanResult,
+)
 from aws_bench.resource_management.cleanup.manager import CleanupManager
 from aws_bench.resource_management.cleanup.models import StackResource
 from aws_bench.resource_management.cleanup.resource_cleaner import ResourceCleaner
@@ -97,12 +101,43 @@ class ResetManager:
             # Regions are independent, so reset them concurrently under a bound.
             region_sem = asyncio.Semaphore(MAX_WORKERS_HEAVY)
 
+            # Phase 0: scan every region's baseline types once, up front, to build the
+            # cross-region corroboration set. A baseline type that enumerates cleanly
+            # (detected or empty) in ANY region is region-available there, so failing to
+            # enumerate it in ANOTHER region is region-unavailability — it cannot hold an
+            # orphan there — not a reset failure. Each region's verify (below) forgives
+            # such a type instead of hard-failing on "Could not enumerate baseline
+            # resource type(s)". A type un-enumerable in EVERY region still fails closed.
+            # This mirrors the two-phase multi-region verify (see
+            # VerifyManager.verify_account_multiregion); the per-region scan is reused as
+            # each region's diagnosis ``precomputed_scan`` so no region is scanned twice.
+            async def _scan_region_bounded(region: str) -> ScanResult | None:
+                async with region_sem:
+                    return await self._scan_baseline_types(snapshot, region, account_id)
+
+            region_scans = dict(
+                zip(
+                    regions,
+                    await asyncio.gather(*(_scan_region_bounded(region) for region in regions)),
+                )
+            )
+            enumerable_elsewhere: set[str] = set()
+            for scan in region_scans.values():
+                if scan is not None:
+                    enumerable_elsewhere |= set(scan.detected.keys()) | scan.empty
+
             async def _reset_region_bounded(
                 region: str,
             ) -> tuple[list[str], dict[str, list[dict]]]:
                 async with region_sem:
                     return await self._reset_region(
-                        env_name, account_id, snapshot, region, scenario_dir
+                        env_name,
+                        account_id,
+                        snapshot,
+                        region,
+                        scenario_dir,
+                        enumerable_elsewhere=enumerable_elsewhere,
+                        diagnosis_scan=region_scans.get(region),
                     )
 
             region_results = await asyncio.gather(
@@ -181,6 +216,37 @@ class ResetManager:
                 unresolved_orphans=orphans,
             )
 
+    async def _scan_baseline_types(
+        self, snapshot: Snapshot, region: str, account_id: str
+    ) -> ScanResult | None:
+        """Fast-scan one region's baseline types for cross-region corroboration.
+
+        Phase 0 of the reset: run once per region before any reset work so the
+        per-region verify can forgive a baseline type that is un-enumerable here
+        but enumerated cleanly in another region (proven region-available there).
+
+        A scan error yields ``None`` — the region simply contributes nothing to the
+        corroboration set (fail-closed: it can never *add* a false toleration).
+
+        Returns:
+            The region's ScanResult for its baseline types, or None on scan error.
+        """
+
+        def _scan() -> ScanResult:
+            with log_context(region):
+                region_session = create_regional_session(self._session, region)
+                region_verify = VerifyManager(
+                    region_session, region_name=region, account_id=account_id
+                )
+                region_snapshot = VerifyManager._filter_snapshot_to_region(snapshot, region)
+                return region_verify.scan_baseline_types(region_snapshot)
+
+        try:
+            return await asyncio.to_thread(_scan)
+        except Exception as exc:  # noqa: BLE001 — a scan error only forfeits this region's corroboration
+            logger.warning(f"Baseline scan for region '{region}' failed, no corroboration: {exc}")
+            return None
+
     async def _reset_region(
         self,
         env_name: str,
@@ -188,8 +254,26 @@ class ResetManager:
         snapshot: Snapshot,
         region: str,
         scenario_dir: Path | None,
+        *,
+        enumerable_elsewhere: set[str] | None = None,
+        diagnosis_scan: ScanResult | None = None,
     ) -> tuple[list[str], dict[str, list[dict]]]:
         """Reset one region against its slice of the baseline.
+
+        Args:
+            env_name: Environment (scenario) name.
+            account_id: AWS account ID being reset.
+            snapshot: The full (all-region) baseline snapshot; filtered to this region.
+            region: The region to reset.
+            scenario_dir: Path to scenario directory for the version (hash) check.
+            enumerable_elsewhere: Baseline types that enumerated cleanly in any region
+                this run (Phase 0). Threaded into every verify below so a type that is
+                un-enumerable here but region-available elsewhere is forgiven rather than
+                hard-failing the reset. A type un-enumerable in every region still fails
+                closed.
+            diagnosis_scan: This region's Phase-0 ScanResult, reused as the initial
+                diagnosis's ``precomputed_scan`` so the region is not scanned twice. The
+                later re-checks re-scan (state changes after deletes).
 
         Returns:
             ``(deleted_stacks, global_resources)`` — the names of stacks deleted
@@ -222,6 +306,8 @@ class ResetManager:
                 snapshot=region_snapshot,
                 scenario_dir=scenario_dir,
                 skip_early=False,
+                precomputed_scan=diagnosis_scan,
+                enumerable_elsewhere=enumerable_elsewhere,
             )
 
             if verify_result.success:
@@ -255,7 +341,9 @@ class ResetManager:
                 # so the not-yet-deleted globals (deleted later by _delete_global_resources)
                 # never false-positive here.
                 orphan_result = await asyncio.to_thread(
-                    region_verify.find_orphan_resources, region_snapshot
+                    lambda: region_verify.find_orphan_resources(
+                        region_snapshot, enumerable_elsewhere=enumerable_elsewhere
+                    )
                 )
                 census = self._census_orphans(orphan_result) if orphan_result is not None else {}
                 unresolved = self._merge_orphan_maps(
@@ -286,6 +374,7 @@ class ResetManager:
                 snapshot=region_snapshot,
                 scenario_dir=scenario_dir,
                 skip_early=False,
+                enumerable_elsewhere=enumerable_elsewhere,
             )
             if not final_verify.success:
                 raise ResetFailure(

--- a/aws_bench/resource_management/verify/manager.py
+++ b/aws_bench/resource_management/verify/manager.py
@@ -339,17 +339,28 @@ class VerifyManager:
             )
         return None
 
-    def find_orphan_resources(self, snapshot: Snapshot) -> VerifyResult | None:
+    def find_orphan_resources(
+        self, snapshot: Snapshot, *, enumerable_elsewhere: set[str] | None = None
+    ) -> VerifyResult | None:
         """Re-run only the new-resource + scan-health census (no stack/drift checks).
 
         Reset's fail-closed backstop after deleting stacks for re-setup: a survivor
         it could not delete or enumerate must fail the reset, not be absorbed into a
         fresh baseline.
+
+        Args:
+            snapshot: The (region-filtered) baseline snapshot.
+            enumerable_elsewhere: Baseline types another region enumerated cleanly this
+                run, for cross-region corroboration in ``_check_new_resources`` — a type
+                proven region-available elsewhere cannot hold an orphan here, so failing
+                to enumerate it here is region-unavailability, not an orphan-hiding gap.
+                None falls back to the error-code allow-list only.
         """
         return self._check_new_resources(
             snapshot.resource_ids,
             snapshot.failed_resource_types,
             snapshot.empty_resource_types,
+            enumerable_elsewhere=enumerable_elsewhere,
         )
 
     def scan_baseline_types(self, snapshot: Snapshot) -> ScanResult:

--- a/tests/resource_management/reset/test_reset_manager.py
+++ b/tests/resource_management/reset/test_reset_manager.py
@@ -177,7 +177,7 @@ def test_reset_account_logs_all_region_failures_before_raising(
     snapshot_with_regions = sample_snapshot
     snapshot_with_regions.regions = ["us-east-1", "us-west-2"]
 
-    async def failing_region(env_name, account_id, snapshot, region, scenario_dir):
+    async def failing_region(env_name, account_id, snapshot, region, scenario_dir, **kwargs):
         raise ResetFailure(reason=f"{region} broke", details={}, suggestion="")
 
     with (
@@ -195,6 +195,104 @@ def test_reset_account_logs_all_region_failures_before_raising(
     # BOTH regions' failures were logged, not just the one that surfaced.
     assert "us-east-1' reset failed" in caplog.text
     assert "us-west-2' reset failed" in caplog.text
+
+
+def test_reset_account_threads_cross_region_corroboration(temp_output_dir, sample_snapshot):
+    """reset_account passes the cross-region enumerable union + per-region scan to reset.
+
+    Every region is scanned up front; the union of enumerable baseline types (detected
+    or empty) is threaded to each region's reset, along with that region's own scan for
+    reuse as the diagnosis precomputed_scan.
+    """
+    from aws_bench.resource_management.ccapi.models import ScanResult
+
+    session = boto3.Session(region_name="us-east-1")
+    manager = ResetManager(session, output_dir=temp_output_dir)
+
+    snapshot_with_regions = sample_snapshot
+    snapshot_with_regions.regions = ["us-east-1", "ap-southeast-1"]
+
+    # us-east-1 enumerates Translate::ParallelData (empty); ap-southeast-1 cannot
+    # (NotAuthorized) but enumerates S3::Bucket. The union proves each region.
+    scans = {
+        "us-east-1": ScanResult(
+            detected={"AWS::S3::Bucket": [{"Identifier": "b1"}]},
+            failed={},
+            empty={"AWS::Translate::ParallelData"},
+        ),
+        "ap-southeast-1": ScanResult(
+            detected={},
+            failed={"AWS::Translate::ParallelData": "NotAuthorizedException"},
+            empty={"AWS::S3::Bucket"},
+        ),
+    }
+
+    async def fake_scan(snapshot, region, account_id):
+        return scans[region]
+
+    captured: dict[str, dict] = {}
+
+    async def fake_reset_region(
+        env_name, account_id, snapshot, region, scenario_dir, **kwargs
+    ):
+        captured[region] = kwargs
+        return [], {}
+
+    with (
+        patch(
+            "aws_bench.resource_management.verify.manager.SnapshotManager.load_snapshot",
+            return_value=snapshot_with_regions,
+        ),
+        patch.object(manager, "_scan_baseline_types", side_effect=fake_scan),
+        patch.object(manager, "_reset_region", side_effect=fake_reset_region),
+    ):
+        asyncio.run(manager.reset_account("test-env", "123456789012"))
+
+    expected_union = {"AWS::S3::Bucket", "AWS::Translate::ParallelData"}
+    assert set(captured) == {"us-east-1", "ap-southeast-1"}
+    for region, kwargs in captured.items():
+        # Cross-region union is passed to every region.
+        assert kwargs["enumerable_elsewhere"] == expected_union
+        # Each region reuses its own Phase-0 scan as the diagnosis scan.
+        assert kwargs["diagnosis_scan"] is scans[region]
+
+
+def test_reset_account_corroboration_empty_when_scans_fail(temp_output_dir, sample_snapshot):
+    """A failed Phase-0 scan contributes nothing to the corroboration set (fail-closed).
+
+    A region whose scan yields None adds no types, so the reset proceeds with no
+    cross-region toleration rather than a falsely-widened enumerable set.
+    """
+    session = boto3.Session(region_name="us-east-1")
+    manager = ResetManager(session, output_dir=temp_output_dir)
+
+    snapshot_with_regions = sample_snapshot
+    snapshot_with_regions.regions = ["us-east-1", "us-west-2"]
+
+    async def fake_scan(snapshot, region, account_id):
+        return None  # scan error path already logs + returns None
+
+    captured: dict[str, dict] = {}
+
+    async def fake_reset_region(
+        env_name, account_id, snapshot, region, scenario_dir, **kwargs
+    ):
+        captured[region] = kwargs
+        return [], {}
+
+    with (
+        patch(
+            "aws_bench.resource_management.verify.manager.SnapshotManager.load_snapshot",
+            return_value=snapshot_with_regions,
+        ),
+        patch.object(manager, "_scan_baseline_types", side_effect=fake_scan),
+        patch.object(manager, "_reset_region", side_effect=fake_reset_region),
+    ):
+        asyncio.run(manager.reset_account("test-env", "123456789012"))
+
+    for kwargs in captured.values():
+        assert kwargs["enumerable_elsewhere"] == set()
+        assert kwargs["diagnosis_scan"] is None
 
 
 @mock_aws

--- a/tests/resource_management/reset/test_reset_manager.py
+++ b/tests/resource_management/reset/test_reset_manager.py
@@ -232,9 +232,7 @@ def test_reset_account_threads_cross_region_corroboration(temp_output_dir, sampl
 
     captured: dict[str, dict] = {}
 
-    async def fake_reset_region(
-        env_name, account_id, snapshot, region, scenario_dir, **kwargs
-    ):
+    async def fake_reset_region(env_name, account_id, snapshot, region, scenario_dir, **kwargs):
         captured[region] = kwargs
         return [], {}
 
@@ -274,9 +272,7 @@ def test_reset_account_corroboration_empty_when_scans_fail(temp_output_dir, samp
 
     captured: dict[str, dict] = {}
 
-    async def fake_reset_region(
-        env_name, account_id, snapshot, region, scenario_dir, **kwargs
-    ):
+    async def fake_reset_region(env_name, account_id, snapshot, region, scenario_dir, **kwargs):
         captured[region] = kwargs
         return [], {}
 


### PR DESCRIPTION
## Description of changes:

### Problem
The per-region env reset verified each region in isolation, so a baseline type that cannot be enumerated in one region (lister returns `NotAuthorized`/`AccessDenied` because the service/type is not offered there) hard-failed the reset with "Could not enumerate baseline resource type(s)" even though the reset itself converged and the type was region-available (enumerated cleanly) in another region the same run scanned. This produced a large class of false-positive reset failures.

### Fix
Extend the cross-region corroboration already used by `verify_account_multiregion` to the reset path:

- `reset_account` now runs a Phase-0 scan of every region's baseline types up front and builds the union of types that enumerated cleanly (detected or empty) in any region.
- That union is threaded as enumerable_elsewhere into all three verify entry points in `_reset_region` (diagnosis, post-delete orphan census, final verify); a type proven region-available elsewhere is forgiven here instead of failing closed.
- Each region's Phase-0 scan is reused as its diagnosis precomputed_scan, so no region is scanned twice.

Fail-closed guarantees preserved: a region whose Phase-0 scan fails contributes nothing to the set, a type un-enumerable in every region still fails closed, and toleration stays scoped to baseline-empty types.

`find_orphan_resources` gains an `enumerable_elsewhere` parameter to carry the set through the post-delete census.

### Testing
Ran all tasks in the `troubleshooting-multiservice` scenario. Verified that both the scenario level reset and env reset worked and successfully tolerated lister failures due to region unavailability which were being marked as reset failures before.

```
2026-08-21 15:27:07 INFO     [troubleshoot-asg-ssh-connectivit__3fsmz3p][scenario-reset] Resetting... trial scenario-reset                                                                                trial.py:197
2026-08-21 15:34:18 INFO     [troubleshoot-asg-ssh-connectivit__3fsmz3p][scenario-reset][PRIMARY/xxxxxxx][us-west-2] Tolerating 5 baseline resource type(s) unavailable in this region (cannot     manager.py:286
                             hold an orphan): ['AWS::CUR::ReportDefinition', 'AWS::IoTSiteWise::ComputationModel', 'AWS::Lightsail::Distribution', 'AWS::Lightsail::Domain',
                             'AWS::Notifications::NotificationConfiguration']
2026-08-21 15:34:18 INFO     [troubleshoot-asg-ssh-connectivit__3fsmz3p][scenario-reset][PRIMARY/xxxxxxx][eu-west-1] Tolerating 3 baseline resource type(s) unavailable in this region (cannot     manager.py:286
                             hold an orphan): ['AWS::Lightsail::Distribution', 'AWS::Lightsail::Domain', 'AWS::Notifications::NotificationConfiguration']
2026-08-21 15:34:18 INFO     [troubleshoot-asg-ssh-connectivit__3fsmz3p][scenario-reset][PRIMARY/xxxxxxx][eu-central-1] Tolerating 11 baseline resource type(s) unavailable in this region (cannot manager.py:286
                             hold an orphan): ['AWS::B2BI::Capability', 'AWS::B2BI::Partnership', 'AWS::B2BI::Profile', 'AWS::B2BI::Transformer', 'AWS::FinSpace::Environment',
                             'AWS::IoTSiteWise::ComputationModel', 'AWS::Kendra::Index', 'AWS::Lightsail::Distribution', 'AWS::Lightsail::Domain', 'AWS::Notifications::NotificationConfiguration',
                             'AWS::Translate::ParallelData']
2026-08-21 15:34:25 INFO     [troubleshoot-asg-ssh-connectivit__3fsmz3p][scenario-reset][PRIMARY/xxxxxxx][ap-northeast-1] Tolerating 12 baseline resource type(s) unavailable in this region       manager.py:286
                             (cannot hold an orphan): ['AWS::Bedrock::AutomatedReasoningPolicy', 'AWS::Bedrock::DataAutomationLibrary', 'AWS::ConnectCampaigns::Campaign',
                             'AWS::FinSpace::Environment', 'AWS::IoTSiteWise::ComputationModel', 'AWS::Lightsail::Distribution', 'AWS::Lightsail::Domain',
                             'AWS::Notifications::NotificationConfiguration', 'AWS::Omics::AnnotationStore', 'AWS::Omics::VariantStore', 'AWS::Translate::ParallelData',
                             'AWS::WorkSpacesThinClient::Environment']
2026-08-21 15:34:31 INFO     [troubleshoot-asg-ssh-connectivit__3fsmz3p][scenario-reset][PRIMARY/xxxxxxx][ap-northeast-2] Tolerating 32 baseline resource type(s) unavailable in this region       manager.py:286
                             (cannot hold an orphan): ['AWS::Bedrock::AutomatedReasoningPolicy', 'AWS::Bedrock::Blueprint', 'AWS::Bedrock::DataAutomationLibrary',
                             'AWS::Bedrock::DataAutomationProject', 'AWS::CodeBuild::Fleet', 'AWS::Connect::TrafficDistributionGroup', 'AWS::ConnectCampaigns::Campaign', 'AWS::DAX::Cluster',
                             'AWS::DAX::SubnetGroup', 'AWS::EC2::VPCEncryptionControl', 'AWS::InspectorV2::CodeSecurityIntegration', 'AWS::InspectorV2::CodeSecurityScanConfiguration',
                             'AWS::Interconnect::Connection', 'AWS::IoTSiteWise::ComputationModel', 'AWS::Lightsail::Distribution', 'AWS::Lightsail::Domain',
                             'AWS::Notifications::NotificationConfiguration', 'AWS::Omics::AnnotationStore', 'AWS::Omics::VariantStore', 'AWS::Rekognition::StreamProcessor',
                             'AWS::Timestream::InfluxDBCluster', 'AWS::Timestream::InfluxDBInstance', 'AWS::Translate::ParallelData', 'AWS::WorkSpacesWeb::BrowserSettings',
                             'AWS::WorkSpacesWeb::DataProtectionSettings', 'AWS::WorkSpacesWeb::IpAccessSettings', 'AWS::WorkSpacesWeb::NetworkSettings', 'AWS::WorkSpacesWeb::Portal',
                             'AWS::WorkSpacesWeb::SessionLogger', 'AWS::WorkSpacesWeb::TrustStore', 'AWS::WorkSpacesWeb::UserAccessLoggingSettings', 'AWS::WorkSpacesWeb::UserSettings']
2026-08-21 15:34:40 INFO     [troubleshoot-asg-ssh-connectivit__3fsmz3p][scenario-reset][PRIMARY/xxxxxxx][ap-southeast-2] Tolerating 18 baseline resource type(s) unavailable in this region       manager.py:286
                             (cannot hold an orphan): ['AWS::B2BI::Capability', 'AWS::B2BI::Partnership', 'AWS::B2BI::Profile', 'AWS::B2BI::Transformer', 'AWS::Connect::TrafficDistributionGroup',
                             'AWS::FinSpace::Environment', 'AWS::Lightsail::Distribution', 'AWS::Lightsail::Domain', 'AWS::Notifications::NotificationConfiguration', 'AWS::Omics::AnnotationStore',
                             'AWS::Omics::Configuration', 'AWS::Omics::RunCache', 'AWS::Omics::RunGroup', 'AWS::Omics::VariantStore', 'AWS::Omics::Workflow', 'AWS::Omics::WorkflowVersion',
                             'AWS::Rekognition::StreamProcessor', 'AWS::Translate::ParallelData']
2026-08-21 15:38:40 INFO     [troubleshoot-asg-ssh-connectivit__3fsmz3p][scenario-reset][PRIMARY/xxxxxxx][us-west-2] Tolerating 5 baseline resource type(s) unavailable in this region (cannot     manager.py:286
                             hold an orphan): ['AWS::CUR::ReportDefinition', 'AWS::IoTSiteWise::ComputationModel', 'AWS::Lightsail::Distribution', 'AWS::Lightsail::Domain',
                             'AWS::Notifications::NotificationConfiguration']
2026-08-21 15:40:01 INFO     [troubleshoot-asg-ssh-connectivit__3fsmz3p][scenario-reset][PRIMARY/xxxxxxx] Account successfully reset to baseline state                                             manager.py:198
  21/21 Mean: 0.571 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1:19:29 0:00:00

troubleshooting-multiservice • claude-code • global.anthropic.claude-sonnet-4-6
┏━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━┓
┃ Trials ┃ Exceptions ┃  Mean ┃
┡━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━┩
│     21 │          0 │ 0.571 │
└────────┴────────────┴───────┘

┏━━━━━━━━┳━━━━━━━┓
┃ Reward ┃ Count ┃
┡━━━━━━━━╇━━━━━━━┩
│ 1.0    │    12 │
│ 0.0    │     9 │
```




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
