### PR TITLE
fix(cleanup): add SageMaker custom handler for resources not suppored by CCAPI

### DIFF
--- a/aws_bench/resource_management/cleanup/handlers/__init__.py
+++ b/aws_bench/resource_management/cleanup/handlers/__init__.py
@@ -35,6 +35,7 @@ from aws_bench.resource_management.cleanup.handlers import (
     s3_bucket_policy,  # noqa: F401
     s3express,  # noqa: F401
     s3tables,  # noqa: F401
+    sagemaker,  # noqa: F401
     servicecatalog,  # noqa: F401
     vpc,  # noqa: F401
 )

--- a/aws_bench/resource_management/cleanup/handlers/sagemaker.py
+++ b/aws_bench/resource_management/cleanup/handlers/sagemaker.py
@@ -1,0 +1,34 @@
+"""SageMaker cleanup handlers.
+
+Cloud Control (CCAPI) does not support ``AWS::SageMaker::EndpointConfig``
+(``UnsupportedActionException``), so endpoint configs left behind after their
+endpoint is deleted are never swept. This custom handler removes them via
+the SageMaker API.
+"""
+
+from __future__ import annotations
+
+import boto3
+
+from aws_bench.resource_management.ccapi.models import Resource
+from aws_bench.resource_management.cleanup.handler_registry import resource_handler
+from aws_bench.resource_management.cleanup.handlers._service_delete import service_delete
+from aws_bench.resource_management.cleanup.models import HandlerResult
+
+# SageMaker returns ValidationException when the resource does not exist.
+_SM_NOT_FOUND_CODES = ("ValidationException",)
+
+
+@resource_handler("AWS::SageMaker::EndpointConfig", role="delete")
+def _delete_endpoint_config(resource: Resource, session: boto3.Session) -> HandlerResult:
+    """Delete a SageMaker EndpointConfig via the SageMaker API."""
+    return service_delete(
+        resource,
+        session,
+        client_name="sagemaker",
+        op_name="delete_endpoint_config",
+        id_param="EndpointConfigName",
+        not_found_codes=_SM_NOT_FOUND_CODES,
+        already_gone_message="SageMaker EndpointConfig already gone",
+        log_label="SageMaker EndpointConfig",
+    )


### PR DESCRIPTION
*Issue #, if available:*
reset and cleanup failed to remove agent-deployed resources of type `AWS::SageMaker::EndpointConfig` in us-east-1 as it's unsupported by CCAPI.

*Description of changes:*
Adding a custom handler to enable to resource removal.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
