### PR TITLE
fix(cleanup): Reclaim Lake Formation governed Glue databases

### DIFF
--- a/aws_bench/resource_management/cleanup/handlers/__init__.py
+++ b/aws_bench/resource_management/cleanup/handlers/__init__.py
@@ -23,6 +23,7 @@ from aws_bench.resource_management.cleanup.handlers import (
     elbv2,  # noqa: F401
     emr,  # noqa: F401
     events,  # noqa: F401
+    glue,  # noqa: F401
     iam,  # noqa: F401
     imagebuilder,  # noqa: F401
     iot,  # noqa: F401

--- a/aws_bench/resource_management/cleanup/handlers/glue.py
+++ b/aws_bench/resource_management/cleanup/handlers/glue.py
@@ -1,0 +1,166 @@
+"""Glue Database cleanup handler.
+
+Lake Formation gates DDL on a governed Data Catalog resource behind its own permission
+table: ``glue:DeleteDatabase`` requires the Lake Formation ``DROP`` permission on that
+database, and IAM alone does not satisfy it — an ``AdministratorAccess`` principal is
+still denied. Lake Formation grants that permission implicitly to the principal that
+*creates* a resource, so a database created by one role is undeletable by another.
+
+The prepare step grants ``DROP`` to the CloudFormation execution role and to the caller's
+own role, on the database and on a wildcard over its tables. Granting requires the caller
+to be a Lake Formation data lake administrator; when it is not, the grant is skipped and
+the delete proceeds unchanged, since the caller may already hold ``DROP``.
+"""
+
+from __future__ import annotations
+
+import time
+
+import boto3
+from botocore.exceptions import BotoCoreError, ClientError
+
+from aws_bench.account_management.preexisting import effective_cfn_role
+from aws_bench.logging.logger import get_logger
+from aws_bench.resource_management.ccapi.models import Resource
+from aws_bench.resource_management.cleanup.handler_registry import resource_handler
+from aws_bench.resource_management.cleanup.models import HandlerResult, HandlerStatus
+from aws_bench.utils.concurrent import build_client
+
+logger = get_logger(__name__)
+
+_GRANT_PERMISSIONS = ("DROP",)
+
+# The database or the target principal does not exist.
+_NOT_FOUND_CODES = ("EntityNotFoundException",)
+
+_CANNOT_GRANT_CODES = ("AccessDeniedException",)
+
+# Outcomes that leave the environment no worse than an absent handler.
+_BENIGN_CODES = frozenset(_NOT_FOUND_CODES + _CANNOT_GRANT_CODES)
+
+# Contention on the Lake Formation permission table, which clears on its own. botocore
+# models no retry for lakeformation, so it is applied here.
+_RETRY_CODES = ("ConcurrentModificationException",)
+_RETRY_ATTEMPTS = 3
+_RETRY_BACKOFF_SEC = 1.0
+
+
+def _caller_principal(session: boto3.Session, identity_arn: str) -> str | None:
+    """Return the caller's Lake Formation principal ARN, or None if it has none.
+
+    ``get_caller_identity`` reports an ``sts`` assumed-role ARN, which Lake Formation
+    rejects. The IAM role ARN it maps to carries the role's path, which the ``sts`` form
+    omits. A user ARN is already a valid principal and passes through unchanged.
+    """
+    fields = identity_arn.split(":")
+    resource = fields[5] if len(fields) > 5 else ""
+    if resource.startswith("user/"):
+        return identity_arn
+    if not resource.startswith("assumed-role/"):
+        return None
+    role_name = resource.split("/")[1]
+    if not role_name:
+        return None
+    try:
+        return build_client(session, "iam").get_role(RoleName=role_name)["Role"]["Arn"]
+    except (ClientError, BotoCoreError) as exc:
+        logger.debug("Could not resolve caller role '%s': %s", role_name, exc)
+        return None
+
+
+def _delete_principals(session: boto3.Session) -> list[str]:
+    """Principal ARNs of the roles that perform the delete, ops role first, deduped.
+
+    Raises:
+        LookupError: If the caller's account cannot be determined.
+    """
+    identity = build_client(session, "sts").get_caller_identity()
+    account = identity.get("Account")
+    if not account:
+        raise LookupError("get_caller_identity returned no Account")
+    principals = [f"arn:aws:iam::{account}:role/{effective_cfn_role()}"]
+    caller = _caller_principal(session, identity.get("Arn", ""))
+    if caller and caller not in principals:
+        principals.append(caller)
+    return principals
+
+
+def _grant(client: object, principal: str, target: dict) -> str | None:
+    """Grant the permissions on one target. Returns None on success, else an error code."""
+    for attempt in range(_RETRY_ATTEMPTS):
+        try:
+            client.grant_permissions(  # type: ignore[attr-defined]
+                Principal={"DataLakePrincipalIdentifier": principal},
+                Resource=target,
+                Permissions=list(_GRANT_PERMISSIONS),
+                PermissionsWithGrantOption=[],
+            )
+            return None
+        except ClientError as exc:
+            code = exc.response.get("Error", {}).get("Code", "")
+            if code in _RETRY_CODES and attempt < _RETRY_ATTEMPTS - 1:
+                time.sleep(_RETRY_BACKOFF_SEC * (attempt + 1))
+                continue
+            return code
+        except BotoCoreError as exc:
+            return type(exc).__name__
+    return None
+
+
+@resource_handler("AWS::Glue::Database", role="prepare")
+def _prepare(resource: Resource, session: boto3.Session) -> HandlerResult:
+    """Grant Lake Formation DROP on the database and its tables before deletion."""
+    database = resource.identifier
+    database_target = {"Database": {"Name": database}}
+    table_target = {"Table": {"DatabaseName": database, "TableWildcard": {}}}
+
+    def _result(status: HandlerStatus, message: str) -> HandlerResult:
+        if status is not HandlerStatus.SUCCESS:
+            logger.warning("Glue database '%s' prepare %s: %s", database, status.value, message)
+        return HandlerResult(
+            resource_id=database,
+            resource_type=resource.type,
+            action="prepare",
+            status=status,
+            message=message,
+        )
+
+    try:
+        client = build_client(session, "lakeformation")
+        principals = _delete_principals(session)
+    except (ClientError, BotoCoreError, LookupError) as exc:
+        return _result(HandlerStatus.FAILED, f"Could not resolve deleting principals: {exc}")
+
+    # Every principal is attempted even after one is rejected: Lake Formation rejects a
+    # grant to a principal that does not exist, and some accounts have no ops role.
+    database_granted: list[str] = []
+    errors: list[str] = []
+    for principal in principals:
+        for target in (database_target, table_target):
+            code = _grant(client, principal, target)
+            if code is not None:
+                errors.append(code)
+            elif target is database_target:
+                database_granted.append(principal)
+
+    # Only DROP on the database authorizes DeleteDatabase; a table-wildcard grant does not.
+    if database_granted:
+        message = (
+            f"Granted {'/'.join(_GRANT_PERMISSIONS)} on '{database}' "
+            f"to {', '.join(database_granted)}"
+        )
+        if errors:
+            message += f" ({len(errors)} rejected: {', '.join(sorted(set(errors)))})"
+        return _result(HandlerStatus.SUCCESS, message)
+
+    codes = ", ".join(sorted(set(errors))) or "no principal to grant to"
+    if errors and all(code in _BENIGN_CODES for code in errors):
+        return _result(
+            HandlerStatus.SKIPPED,
+            f"No Lake Formation grant possible on '{database}' ({codes}); "
+            "deletion proceeds without one",
+        )
+    return _result(
+        HandlerStatus.FAILED,
+        f"Failed to grant Lake Formation permissions on '{database}': {codes}",
+    )

--- a/aws_bench/resource_management/cleanup/stack_deleter.py
+++ b/aws_bench/resource_management/cleanup/stack_deleter.py
@@ -61,7 +61,13 @@ PROGRESS_LOG_INTERVAL_SEC = 60  # Log progress every 60 seconds during stack del
 # indicating CFN silently refused because another stack imports its exports.
 _EXPORT_BLOCKED = "EXPORT_BLOCKED"
 _EXPORT_BLOCKED_REASON = "Blocked by cross-stack export dependencies"
+
 DEADLINE_EXTENSION_SEC = 600  # Extend deadline by 10 minutes when stack still in progress
+
+# UNKNOWN is swept because the check did not answer, not because the resource is gone. The
+# excluded outcomes: ABSENT is confirmed gone, SKIPPED is a type CCAPI cannot act on, and
+# UNCHECKED_SUBRESOURCE is left to its parent's delete.
+_SWEEPABLE_EXISTENCE = frozenset({ExistenceStatus.EXISTS, ExistenceStatus.UNKNOWN})
 
 # A subnet/VPC/security-group is the only thing a requester-managed ENI can pin in
 # DELETE_FAILED. When a stack's outstanding failures are confined to these types and
@@ -515,9 +521,9 @@ class StackDeleter:
 
         ``snapshot`` is the stack's resource list captured just before the
         force-delete. Everything not already ``DELETE_COMPLETE`` there is a
-        candidate leftover; the verifier narrows that to resources that still
-        EXIST, and the cleaner deletes them (``prepare`` empties buckets via the
-        S3 handler, then custom handlers / CCAPI remove the resource itself).
+        candidate leftover; only those in ``_SWEEPABLE_EXISTENCE`` reach the cleaner,
+        which deletes them (``prepare`` empties buckets via the S3 handler, then
+        custom handlers / CCAPI remove the resource itself).
 
         Orphaned fixed-name resources are the motivating case: a bucket whose
         name is baked into the template blocks every future deploy with
@@ -543,9 +549,25 @@ class StackDeleter:
             survivors = [
                 by_key[(v.logical_id, v.physical_id)]
                 for v in verified
-                if v.existence_status == ExistenceStatus.EXISTS
+                if v.existence_status in _SWEEPABLE_EXISTENCE
                 and (v.logical_id, v.physical_id) in by_key
             ]
+            dropped = [
+                (v.existence_status, by_key[(v.logical_id, v.physical_id)])
+                for v in verified
+                if v.existence_status not in _SWEEPABLE_EXISTENCE
+                and (v.logical_id, v.physical_id) in by_key
+            ]
+            if dropped:
+                logger.debug(
+                    "Stack '%s': %d abandoned candidate(s) not swept: %s",
+                    stack_name,
+                    len(dropped),
+                    ", ".join(
+                        f"{r.logical_id}({r.resource_type}, {status.value})"
+                        for status, r in dropped
+                    ),
+                )
             if not survivors:
                 return []
             logger.debug(

--- a/aws_bench/resource_management/cleanup/verification/manager.py
+++ b/aws_bench/resource_management/cleanup/verification/manager.py
@@ -11,6 +11,7 @@ from aws_bench.logging.logger import get_logger
 from aws_bench.resource_management.ccapi.exceptions import (
     ResourceExistenceCheckError,
     ResourceExistenceThrottledError,
+    ResourceExistenceUnsupportedError,
 )
 from aws_bench.resource_management.ccapi.manager import CloudControlManager, Resource
 from aws_bench.resource_management.ccapi.models import (
@@ -53,7 +54,7 @@ class ResourceVerifier:
             - EXISTS: Resource still exists
             - ABSENT: Resource confirmed gone
             - SKIPPED: Resource type cannot be verified (e.g., Custom::*)
-            - UNKNOWN: Verification failed (transient error)
+            - UNKNOWN: Verification did not answer (throttled, denied, or errored)
             - UNCHECKED_SUBRESOURCE: Sub-resource that requires parent context
 
         Limits concurrency to avoid thundering herd of API calls.
@@ -124,10 +125,13 @@ class ResourceVerifier:
             # accurate label is defence-in-depth. Must precede the base-class catch.
             logger.debug("CCAPI throttled verifying %s '%s'; marking UNKNOWN", rtype, pid)
             return _make_result(ExistenceStatus.UNKNOWN)
-        except ResourceExistenceCheckError:
-            # Expected error for unsupported CCAPI types
+        except ResourceExistenceUnsupportedError:
+            # Must precede the base-class catch.
             logger.debug("CCAPI does not support %s '%s'", rtype, pid)
             return _make_result(ExistenceStatus.SKIPPED)
+        except ResourceExistenceCheckError:
+            logger.debug("Existence check failed for %s '%s'; marking UNKNOWN", rtype, pid)
+            return _make_result(ExistenceStatus.UNKNOWN)
         except ClientError as exc:
             code = exc.response.get("Error", {}).get("Code", "")
             if code in UNSUPPORTED_CCAPI_ERROR_CODES:

--- a/tests/resource_management/cleanup/test_handlers_glue.py
+++ b/tests/resource_management/cleanup/test_handlers_glue.py
@@ -1,0 +1,309 @@
+"""Tests for the Glue Database cleanup handler."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from botocore.exceptions import ClientError, EndpointConnectionError
+
+from aws_bench.account_management.preexisting import ACCOUNT_CONFIG_ENV_VAR
+from aws_bench.resource_management.ccapi.models import Resource
+from aws_bench.resource_management.cleanup.handler_registry import PREPARE_REGISTRY
+from aws_bench.resource_management.cleanup.handlers import glue as glue_handler
+from aws_bench.resource_management.cleanup.models import HandlerStatus
+
+_TYPE = "AWS::Glue::Database"
+_OPS_ROLE = "arn:aws:iam::111122223333:role/cfn-service-execution"
+_CALLER_ROLE = "arn:aws:iam::111122223333:role/some-path/OrganizationAccountAccessRole"
+_CALLER_STS = "arn:aws:sts::111122223333:assumed-role/OrganizationAccountAccessRole/sess"
+
+
+@pytest.fixture(autouse=True)
+def _no_account_config(monkeypatch):
+    """Pin effective_cfn_role() away from the ambient account config.
+
+    It resolves through the account-config env var, so a shell in preexisting mode would
+    name a different ops role and fail every assertion here.
+    """
+    monkeypatch.delenv(ACCOUNT_CONFIG_ENV_VAR, raising=False)
+
+
+def _resource(name: str = "analytics_db_111122223333_us-east-1") -> Resource:
+    return Resource(type=_TYPE, identifier=name)
+
+
+def _session(lf: MagicMock, caller_arn: str = _CALLER_STS, caller_role: str = _CALLER_ROLE):
+    """A session whose lakeformation/sts/iam clients are all controllable."""
+    sts = MagicMock()
+    sts.get_caller_identity.return_value = {"Account": "111122223333", "Arn": caller_arn}
+    iam = MagicMock()
+    iam.get_role.return_value = {"Role": {"Arn": caller_role}}
+    clients = {"lakeformation": lf, "sts": sts, "iam": iam}
+    session = MagicMock()
+    session.client.side_effect = lambda service, **_kw: clients[service]
+    return session
+
+
+def _grant_calls(lf: MagicMock) -> set[tuple[str, str]]:
+    """(principal, resource-kind) pairs the handler attempted a grant for."""
+    return {
+        (
+            call.kwargs["Principal"]["DataLakePrincipalIdentifier"],
+            next(iter(call.kwargs["Resource"])),
+        )
+        for call in lf.grant_permissions.call_args_list
+    }
+
+
+def _denying(*codes: str, target_kind: str | None = None):
+    """A grant_permissions side effect raising `codes[0]`, optionally for one target kind."""
+
+    def _side_effect(**kwargs):
+        if target_kind is None or target_kind in kwargs["Resource"]:
+            raise ClientError(
+                {"Error": {"Code": codes[0], "Message": "denied"}}, "GrantPermissions"
+            )
+        return {}
+
+    return _side_effect
+
+
+# -- registry wiring ----------------------------------------------------------
+
+
+def test_handler_is_registered_as_a_prepare_handler():
+    """PREPARE_REGISTRY maps AWS::Glue::Database to this handler."""
+    assert PREPARE_REGISTRY[_TYPE] is glue_handler._prepare
+
+
+def test_registered_handler_grants_when_invoked_through_the_registry():
+    lf = MagicMock()
+    result = PREPARE_REGISTRY[_TYPE](_resource(), _session(lf))
+    assert result.status == HandlerStatus.SUCCESS
+    assert lf.grant_permissions.called
+
+
+# -- grant shape --------------------------------------------------------------
+
+
+def test_prepare_grants_drop_to_ops_role_and_caller():
+    """DROP is granted on the database and its tables, to both deleting principals.
+
+    CloudFormation performs the delete as the ops role and a direct sweep performs it as
+    the caller, so both need the grant.
+    """
+    lf = MagicMock()
+    result = glue_handler._prepare(_resource(), _session(lf))
+
+    assert result.status == HandlerStatus.SUCCESS
+    assert _grant_calls(lf) == {
+        (_OPS_ROLE, "Database"),
+        (_OPS_ROLE, "Table"),
+        (_CALLER_ROLE, "Database"),
+        (_CALLER_ROLE, "Table"),
+    }
+    assert {tuple(c.kwargs["Permissions"]) for c in lf.grant_permissions.call_args_list} == {
+        ("DROP",)
+    }
+
+
+def test_prepare_grant_targets_are_exact():
+    """The database and table-wildcard specs are asserted in full.
+
+    A wrong inner parameter name is accepted by a mock but rejected by botocore, so the
+    outer key alone is not enough to pin the request shape.
+    """
+    lf = MagicMock()
+    glue_handler._prepare(_resource("mydb"), _session(lf))
+
+    specs = [c.kwargs["Resource"] for c in lf.grant_permissions.call_args_list]
+    assert {"Database": {"Name": "mydb"}} in specs
+    assert {"Table": {"DatabaseName": "mydb", "TableWildcard": {}}} in specs
+    calls = lf.grant_permissions.call_args_list
+    assert all(c.kwargs["PermissionsWithGrantOption"] == [] for c in calls)
+
+
+def test_prepare_dedupes_when_caller_is_the_ops_role():
+    """The ops role and caller resolving to one principal yields one grant per target."""
+    lf = MagicMock()
+    session = _session(
+        lf,
+        caller_arn="arn:aws:sts::111122223333:assumed-role/cfn-service-execution/sess",
+        caller_role=_OPS_ROLE,
+    )
+    glue_handler._prepare(_resource(), session)
+
+    assert _grant_calls(lf) == {(_OPS_ROLE, "Database"), (_OPS_ROLE, "Table")}
+
+
+# -- caller principal resolution ---------------------------------------------
+
+
+def test_prepare_resolves_the_caller_role_through_iam():
+    """The caller principal comes from IAM, not from rewriting the sts ARN.
+
+    An assumed-role ARN omits the role's IAM path, so a rebuilt ARN names a role that does
+    not exist and Lake Formation rejects the grant.
+    """
+    lf = MagicMock()
+    session = _session(lf, caller_role="arn:aws:iam::111122223333:role/deep/path/Admin")
+    glue_handler._prepare(_resource(), session)
+
+    principals = {p for p, _ in _grant_calls(lf)}
+    assert "arn:aws:iam::111122223333:role/deep/path/Admin" in principals
+
+
+def test_prepare_passes_a_user_caller_through_unchanged():
+    """A user ARN is already a valid Lake Formation principal."""
+    lf = MagicMock()
+    user = "arn:aws:iam::111122223333:user/alice"
+    glue_handler._prepare(_resource(), _session(lf, caller_arn=user))
+
+    assert user in {p for p, _ in _grant_calls(lf)}
+
+
+def test_prepare_grants_ops_role_only_when_the_caller_has_no_principal():
+    """An identity that is neither a role nor a user is dropped, not guessed at."""
+    lf = MagicMock()
+    root = "arn:aws:iam::111122223333:root"
+    result = glue_handler._prepare(_resource(), _session(lf, caller_arn=root))
+
+    assert result.status == HandlerStatus.SUCCESS
+    assert {p for p, _ in _grant_calls(lf)} == {_OPS_ROLE}
+
+
+def test_prepare_fails_when_the_account_is_unavailable():
+    """A caller identity with no Account yields FAILED rather than raising."""
+    lf = MagicMock()
+    session = _session(lf)
+    session.client("sts").get_caller_identity.return_value = {"Arn": _CALLER_STS}
+
+    result = glue_handler._prepare(_resource(), session)
+    assert result.status == HandlerStatus.FAILED
+    assert not lf.grant_permissions.called
+
+
+# -- classification -----------------------------------------------------------
+
+
+def test_prepare_is_skipped_when_only_the_table_grant_lands():
+    """Only the table-wildcard grant landing yields SKIPPED, not SUCCESS."""
+    lf = MagicMock()
+    lf.grant_permissions.side_effect = _denying("AccessDeniedException", target_kind="Database")
+
+    result = glue_handler._prepare(_resource(), _session(lf))
+    assert result.status == HandlerStatus.SKIPPED
+
+
+def test_prepare_continues_after_one_principal_is_rejected():
+    """A grant rejected for one principal must not skip the other.
+
+    Some accounts have no ops role, and Lake Formation rejects a grant to a principal that
+    does not exist. The caller's grant is the one the direct sweep path needs.
+    """
+    lf = MagicMock()
+
+    def _side_effect(**kwargs):
+        if kwargs["Principal"]["DataLakePrincipalIdentifier"] == _OPS_ROLE:
+            raise ClientError(
+                {"Error": {"Code": "EntityNotFoundException", "Message": "no principal"}},
+                "GrantPermissions",
+            )
+        return {}
+
+    lf.grant_permissions.side_effect = _side_effect
+    result = glue_handler._prepare(_resource(), _session(lf))
+
+    assert result.status == HandlerStatus.SUCCESS
+    assert (_CALLER_ROLE, "Database") in _grant_calls(lf)
+
+
+def test_prepare_database_already_gone_is_skipped():
+    """EntityNotFoundException on every target means there is nothing to grant on."""
+    lf = MagicMock()
+    lf.grant_permissions.side_effect = _denying("EntityNotFoundException")
+    assert glue_handler._prepare(_resource(), _session(lf)).status == HandlerStatus.SKIPPED
+
+
+def test_prepare_without_admin_rights_is_skipped_not_failed():
+    """A caller that is not a data lake administrator cannot grant; the delete still runs.
+
+    The caller may already hold DROP, so a denied grant is not a handler failure.
+    """
+    lf = MagicMock()
+    lf.grant_permissions.side_effect = _denying("AccessDeniedException")
+    assert glue_handler._prepare(_resource(), _session(lf)).status == HandlerStatus.SKIPPED
+
+
+def test_prepare_unexpected_error_is_failed_not_skipped():
+    """An error outside the benign set is FAILED, so it is not mistaken for a clean skip."""
+    lf = MagicMock()
+    lf.grant_permissions.side_effect = _denying("InternalServiceException")
+    assert glue_handler._prepare(_resource(), _session(lf)).status == HandlerStatus.FAILED
+
+
+def test_prepare_mixed_errors_are_failed():
+    """A benign code alongside an unexpected one is FAILED.
+
+    Classifying on the benign member alone would report a real malfunction as an
+    intentional skip.
+    """
+    lf = MagicMock()
+    codes = iter(
+        [
+            "AccessDeniedException",
+            "InternalServiceException",
+            "AccessDeniedException",
+            "AccessDeniedException",
+        ]
+    )
+
+    def _side_effect(**_kwargs):
+        raise ClientError({"Error": {"Code": next(codes), "Message": "x"}}, "GrantPermissions")
+
+    lf.grant_permissions.side_effect = _side_effect
+    assert glue_handler._prepare(_resource(), _session(lf)).status == HandlerStatus.FAILED
+
+
+def test_prepare_connection_error_is_failed():
+    """A Region without a Lake Formation endpoint surfaces as FAILED, never as a raise."""
+    lf = MagicMock()
+    lf.grant_permissions.side_effect = EndpointConnectionError(endpoint_url="https://lf")
+    assert glue_handler._prepare(_resource(), _session(lf)).status == HandlerStatus.FAILED
+
+
+# -- retry --------------------------------------------------------------------
+
+
+def test_prepare_retries_transient_contention(monkeypatch):
+    """Contention on the permission table is retried, not reported as a failure."""
+    monkeypatch.setattr(glue_handler.time, "sleep", lambda _s: None)
+    lf = MagicMock()
+    attempts = {"n": 0}
+
+    def _side_effect(**_kwargs):
+        attempts["n"] += 1
+        if attempts["n"] == 1:
+            raise ClientError(
+                {"Error": {"Code": "ConcurrentModificationException", "Message": "busy"}},
+                "GrantPermissions",
+            )
+        return {}
+
+    lf.grant_permissions.side_effect = _side_effect
+    result = glue_handler._prepare(_resource(), _session(lf))
+
+    assert result.status == HandlerStatus.SUCCESS
+    assert attempts["n"] == 5  # one retried call plus the remaining three targets
+
+
+def test_prepare_gives_up_on_persistent_contention(monkeypatch):
+    """Contention that never clears is reported, not retried forever."""
+    monkeypatch.setattr(glue_handler.time, "sleep", lambda _s: None)
+    lf = MagicMock()
+    lf.grant_permissions.side_effect = _denying("ConcurrentModificationException")
+
+    result = glue_handler._prepare(_resource(), _session(lf))
+    assert result.status == HandlerStatus.FAILED
+    assert lf.grant_permissions.call_count == glue_handler._RETRY_ATTEMPTS * 4

--- a/tests/resource_management/cleanup/test_stack_deleter.py
+++ b/tests/resource_management/cleanup/test_stack_deleter.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -1269,6 +1270,89 @@ def test_sweep_force_abandoned_noop_when_nothing_survives(deleter):
 
     mock_cleanup.assert_not_awaited()
     assert "force_abandoned_swept" not in deleter._manifest.get("my-stack", {})
+
+
+def test_sweep_force_abandoned_attempts_unverified_resources(deleter):
+    """An UNKNOWN resource is swept; a SKIPPED one is not.
+
+    UNKNOWN means the existence check could not answer, not that the resource is gone, and
+    deleting an already-absent resource is a no-op. SKIPPED asserts CCAPI cannot act on the
+    type, so a delete through it is equally impossible.
+    """
+    snapshot = _abandoned_snapshot()
+    verifications = [
+        _verification(snapshot[0], ExistenceStatus.SKIPPED),
+        _verification(snapshot[1], ExistenceStatus.UNKNOWN),
+        _verification(snapshot[2], ExistenceStatus.ABSENT),
+    ]
+    with (
+        patch.object(
+            deleter._verifier,
+            "verify_resources",
+            new_callable=AsyncMock,
+            return_value=verifications,
+        ),
+        patch.object(
+            deleter._cleaner, "cleanup", new_callable=AsyncMock, return_value={}
+        ) as mock_cleanup,
+    ):
+        asyncio.run(deleter._sweep_force_abandoned("my-stack", snapshot))
+
+    mock_cleanup.assert_awaited_once()
+    cleanup_args, _ = mock_cleanup.call_args_list[0]
+    assert [r.logical_id for r in cleanup_args[0]] == ["ALBLogsBucket"]
+    assert deleter._manifest["my-stack"]["force_abandoned_swept"] == ["ALBLogsBucket"]
+
+
+def test_sweep_force_abandoned_leaves_unchecked_subresources_to_their_parent(deleter):
+    """An UNCHECKED_SUBRESOURCE candidate is not swept.
+
+    A sub-resource cannot be verified or deleted without its parent's context, so it is
+    reclaimed by deleting the parent rather than attempted on its own.
+    """
+    snapshot = _abandoned_snapshot()
+    verifications = [
+        _verification(snapshot[0], ExistenceStatus.UNCHECKED_SUBRESOURCE),
+        _verification(snapshot[1], ExistenceStatus.UNCHECKED_SUBRESOURCE),
+    ]
+    with (
+        patch.object(
+            deleter._verifier,
+            "verify_resources",
+            new_callable=AsyncMock,
+            return_value=verifications,
+        ),
+        patch.object(deleter._cleaner, "cleanup", new_callable=AsyncMock) as mock_cleanup,
+    ):
+        stuck = asyncio.run(deleter._sweep_force_abandoned("my-stack", snapshot))
+
+    mock_cleanup.assert_not_awaited()
+    assert stuck == []
+
+
+def test_sweep_force_abandoned_logs_dropped_candidates(deleter, caplog):
+    """Candidates excluded from the sweep are logged even when others are swept."""
+    snapshot = _abandoned_snapshot()
+    verifications = [
+        _verification(snapshot[0], ExistenceStatus.SKIPPED),
+        _verification(snapshot[1], ExistenceStatus.EXISTS),
+    ]
+    with (
+        patch.object(
+            deleter._verifier,
+            "verify_resources",
+            new_callable=AsyncMock,
+            return_value=verifications,
+        ),
+        patch.object(deleter._cleaner, "cleanup", new_callable=AsyncMock, return_value={}),
+        caplog.at_level(
+            logging.DEBUG, logger="aws_bench.resource_management.cleanup.stack_deleter"
+        ),
+    ):
+        asyncio.run(deleter._sweep_force_abandoned("my-stack", snapshot))
+
+    assert "not swept" in caplog.text
+    assert "AutoDeleteCR" in caplog.text
 
 
 def test_sweep_force_abandoned_is_best_effort(deleter):

--- a/tests/resource_management/cleanup/test_verification_manager.py
+++ b/tests/resource_management/cleanup/test_verification_manager.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -176,13 +177,12 @@ def test_verify_unknown_on_non_ccapi_error(mock_ccm):
     assert result[0].existence_status == ExistenceStatus.UNKNOWN
 
 
-def test_verify_throttled_returns_unknown_not_skipped(mock_ccm):
-    """A throttled existence check must map to UNKNOWN, not SKIPPED.
+def test_verify_throttled_returns_unknown_not_skipped(mock_ccm, caplog):
+    """A throttled existence check maps to UNKNOWN, and says it was a throttle.
 
     SKIPPED is the 'genuinely unsupported' bucket; a throttled resource is merely
-    unverified. Bucketing it as SKIPPED silently drops it from the orphan count
-    (stack_deleter force-cleans only EXISTS), so a throttle can make a dirty
-    account read as clean. Regression guard for RC10.
+    unverified. Bucketing it as SKIPPED drops it from the orphan count, so a throttle can
+    make a dirty account read as clean.
     """
     from aws_bench.resource_management.ccapi.exceptions import ResourceExistenceThrottledError
 
@@ -193,8 +193,12 @@ def test_verify_throttled_returns_unknown_not_skipped(mock_ccm):
         resource_type="AWS::Lambda::Function",
         status="CREATE_COMPLETE",
     )
-    result = asyncio.run(ResourceVerifier(MagicMock()).verify_resources([resource]))
+    with caplog.at_level(
+        logging.DEBUG, logger="aws_bench.resource_management.cleanup.verification.manager"
+    ):
+        result = asyncio.run(ResourceVerifier(MagicMock()).verify_resources([resource]))
     assert result[0].existence_status == ExistenceStatus.UNKNOWN
+    assert "throttled" in caplog.text.lower()
 
 
 def test_verify_unsupported_ccapi_still_skipped(mock_ccm):
@@ -202,9 +206,11 @@ def test_verify_unsupported_ccapi_still_skipped(mock_ccm):
 
     Guards against the throttle carve-out accidentally regressing the SKIPPED path.
     """
-    from aws_bench.resource_management.ccapi.exceptions import ResourceExistenceCheckError
+    from aws_bench.resource_management.ccapi.exceptions import ResourceExistenceUnsupportedError
 
-    mock_ccm.resource_exists.side_effect = ResourceExistenceCheckError("CCAPI does not support X")
+    mock_ccm.resource_exists.side_effect = ResourceExistenceUnsupportedError(
+        "CCAPI does not support X"
+    )
     resource = StackResource(
         logical_id="L1",
         physical_id="x",
@@ -213,6 +219,28 @@ def test_verify_unsupported_ccapi_still_skipped(mock_ccm):
     )
     result = asyncio.run(ResourceVerifier(MagicMock()).verify_resources([resource]))
     assert result[0].existence_status == ExistenceStatus.SKIPPED
+
+
+def test_verify_check_failure_returns_unknown_not_skipped(mock_ccm):
+    """A failed existence check maps to UNKNOWN, not SKIPPED.
+
+    SKIPPED asserts the type itself cannot be acted on, so the force-abandoned sweep
+    drops it. A check that failed (e.g. AccessDenied on a governed resource) leaves
+    existence unverified, not disproved, so the resource must stay a delete candidate.
+    """
+    from aws_bench.resource_management.ccapi.exceptions import ResourceExistenceCheckError
+
+    mock_ccm.resource_exists.side_effect = ResourceExistenceCheckError(
+        "Failed to check existence of AWS::Glue::Database 'db': AccessDeniedException"
+    )
+    resource = StackResource(
+        logical_id="GlueDatabase",
+        physical_id="analytics_db_111111111111_us-east-1",
+        resource_type="AWS::Glue::Database",
+        status="DELETE_FAILED",
+    )
+    result = asyncio.run(ResourceVerifier(MagicMock()).verify_resources([resource]))
+    assert result[0].existence_status == ExistenceStatus.UNKNOWN
 
 
 def test_verify_preserves_input_order(mock_ccm):


### PR DESCRIPTION
## Problem

Two independent defects combine to leak a Lake Formation governed Glue database during teardown, and to report that teardown as clean.

**1. The delete is denied.** Lake Formation gates DDL on a governed Data Catalog resource behind its own permission table: `glue:DeleteDatabase` requires the Lake Formation `DROP` permission, and IAM does not satisfy it — a principal holding `AdministratorAccess` is still denied with `Insufficient Lake Formation permission(s): Required Drop`. Lake Formation grants that permission implicitly to the principal that *creates* a resource, so a database created by the deploy role cannot be deleted by the role CloudFormation assumes for teardown. The stack ends `DELETE_FAILED`, `FORCE_DELETE_STACK` abandons the database, and because the database name is deterministic, every later deploy of that stack fails with `AlreadyExists`.

**2. The leak is invisible.** The post-force-delete sweep is the fallback that reclaims abandoned resources, but it kept only resources whose existence check returned `EXISTS`. A governed database denies that check to a principal with no permission on it, so the resource was dropped with no delete attempt and no log line. `glue:GetDatabases` filters on the same permission, so the independent orphan scan cannot see it either — the sweep is the only line of defence, and it was silently declining to act.

## Fix

**`cleanup/verification/manager.py`** — `ResourceVerifier` caught only the base `ResourceExistenceCheckError` and mapped every failure to `SKIPPED`, asserting the resource *type* was unverifiable. The dedicated `ResourceExistenceUnsupportedError` is now caught first and keeps `SKIPPED`; any other failure maps to `UNKNOWN`.

**`cleanup/stack_deleter.py`** — the sweep treats `UNKNOWN` as sweepable. Deleting an already-absent resource is a no-op through CCAPI, so attempting costs one call, while dropping it leaks a resource whose fixed name blocks the next deploy. `ABSENT`, `SKIPPED` and `UNCHECKED_SUBRESOURCE` stay excluded — the last because a sub-resource is reclaimed by deleting its parent. Every excluded candidate is now logged with its status, not only the case where nothing is sweepable.

**`cleanup/handlers/glue.py`** (new) — a `prepare` handler grants Lake Formation `DROP` on the database, and on a wildcard over its tables, to the role CloudFormation assumes and to the caller's own role: the two principals that perform the delete. A Glue table's CloudFormation physical ID is the bare table name, so a table-scoped handler could not name the database its grant needs; the wildcard covers them.

Details worth a reviewer's attention:

- Success is gated on the **database** grant specifically, since only that authorizes `DeleteDatabase` — a table-wildcard grant does not.
- The caller's principal is resolved through `iam:GetRole` rather than rebuilt from the `sts` assumed-role ARN, which omits the role's IAM path.
- Every principal is attempted even after one is rejected, because the two are needed by different delete paths and the ops role does not exist in every account.
- Contention on the permission table is retried, as botocore models no retry for `lakeformation`.
- Granting requires the caller to be a data lake administrator. When it is not, the result is `SKIPPED` and the delete proceeds unchanged, since the caller may already hold `DROP`. The prepare stage keeps only successful results, so the handler logs its own non-success outcome.

## Verification

`make check` is green: ruff, `pyright` 0 errors, 3003 tests, 89% coverage.

Beyond unit tests, this was exercised end to end against a real AWS account with Lake Formation governance enabled:

- a stack delete performed through a role without the Lake Formation grant fails on the governed database, and succeeds after the handler runs;
- `DROP` alone is sufficient — it carries visibility, so no separate read permission is granted;
- a caller that is not a data lake administrator yields a skip and the delete still proceeds;
- permission rows are removed along with the database, so the grant needs no cleanup step.

Each new test was also checked against a simulated revert of the production change it guards, to confirm it fails when that change is undone.

## Known limitations

- The grant is written in the Region the session carries. Callers that build a regional session per Region are correct; a caller sharing one session across Regions is not.
- A database enumerated only as part of a parent stack is not reached by the prepare stage.
- Four existing custom delete handlers raise or report failure for an already-absent resource. A resource that is both unverifiable and has such a handler can therefore be reported as an orphan after this change. Left as a separate fix, on observation, rather than widening this one.