### PR TITLE
feat(agents): add CloudGeni benchmark adapter

### DIFF
--- a/aws_bench/agents/cloudgeni.py
+++ b/aws_bench/agents/cloudgeni.py
@@ -1,0 +1,189 @@
+"""Harbor installed-agent adapter for running AWS-Bench through CloudGeni."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+from harbor.agents.installed.base import (
+    BaseInstalledAgent,
+    NonZeroAgentExitCodeError,
+    with_prompt_template,
+)
+from harbor.environments.base import BaseEnvironment
+from harbor.models.agent.context import AgentContext
+
+_RUNNER_PATH = Path(__file__).with_name("cloudgeni_runner.py")
+_REMOTE_RUNNER_PATH = "/installed-agent/cloudgeni_runner.py"
+_REMOTE_PROMPT_PATH = "/installed-agent/cloudgeni-prompt.txt"
+_STATE_FILENAME = "cloudgeni-state.json"
+_REQUIRED_ENV = (
+    "CLOUDGENI_API_URL",
+    "CLOUDGENI_API_KEY",
+    "CLOUDGENI_ORGANIZATION_ID",
+    "CLOUDGENI_WORKSPACE_ID",
+)
+
+
+class CloudGeniAgent(BaseInstalledAgent):
+    """Delegate one isolated AWS-Bench trial to CloudGeni's OpenGeni runtime."""
+
+    SUPPORTS_ATIF: bool = False
+
+    @staticmethod
+    def name() -> str:
+        """Return the custom agent identifier."""
+        return "cloudgeni"
+
+    def get_version_command(self) -> str | None:
+        """CloudGeni is a remote service, so there is no container binary version."""
+        return None
+
+    async def install(self, environment: BaseEnvironment) -> None:
+        """Ensure the standard-library bridge has a Python interpreter."""
+        result = await environment.exec(
+            command=(
+                "command -v python3 >/dev/null || "
+                "(apt-get update -qq && apt-get install -y -qq python3)"
+            ),
+            user="root",
+        )
+        if result.return_code != 0:
+            raise NonZeroAgentExitCodeError("Could not install Python for the CloudGeni bridge")
+
+    async def setup(self, environment: BaseEnvironment) -> None:
+        """Upload the bridge without placing CloudGeni credentials on a command line."""
+        await self.install(environment)
+        runner = base64.b64encode(_RUNNER_PATH.read_bytes()).decode()
+        result = await environment.exec(
+            command=(
+                f"mkdir -p /installed-agent && echo '{runner}' | base64 -d > {_REMOTE_RUNNER_PATH}"
+            ),
+            user="root",
+        )
+        if result.return_code != 0:
+            raise NonZeroAgentExitCodeError("Could not upload the CloudGeni bridge")
+
+    def _require_configuration(self) -> None:
+        missing = [name for name in _REQUIRED_ENV if not (self._get_env(name) or "").strip()]
+        if missing:
+            raise ValueError(
+                "CloudGeni agent requires --ae values for: " + ", ".join(sorted(missing))
+            )
+
+    @with_prompt_template
+    async def run(
+        self, instruction: str, environment: BaseEnvironment, context: AgentContext
+    ) -> None:
+        """Run the bridge, then enforce host-side cancellation and lease cleanup."""
+        self._require_configuration()
+        encoded_prompt = base64.b64encode(instruction.encode()).decode()
+        prompt_result = await environment.exec(
+            command=f"echo '{encoded_prompt}' | base64 -d > {_REMOTE_PROMPT_PATH}"
+        )
+        if prompt_result.return_code != 0:
+            raise NonZeroAgentExitCodeError("Could not upload the CloudGeni trial prompt")
+
+        try:
+            result = await environment.exec(
+                command=f"python3 {_REMOTE_RUNNER_PATH}",
+                env=dict(self._extra_env),
+            )
+            if result.return_code != 0:
+                raise NonZeroAgentExitCodeError(
+                    f"CloudGeni bridge failed (exit {result.return_code}); "
+                    f"see /logs/agent/{_STATE_FILENAME}"
+                )
+        finally:
+            await asyncio.to_thread(self._host_cleanup)
+
+    def _host_api_url(self) -> str:
+        configured = self._get_env("CLOUDGENI_HOST_API_URL") or self._get_env("CLOUDGENI_API_URL")
+        if not configured:
+            return ""
+        return configured.replace("host.docker.internal", "localhost").rstrip("/")
+
+    def _host_request(self, method: str, path: str) -> int:
+        root = self._host_api_url()
+        if not root.endswith("/api/v1"):
+            root = f"{root}/api/v1"
+        request = urllib.request.Request(
+            f"{root}{path}",
+            method=method,
+            headers={
+                "Accept": "application/json",
+                "X-CLOUDGENI-API-KEY": self._get_env("CLOUDGENI_API_KEY") or "",
+            },
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                return response.status
+        except urllib.error.HTTPError as error:
+            return error.code
+        except urllib.error.URLError:
+            return 0
+
+    def _host_cleanup(self) -> None:
+        """Best-effort cleanup that still runs when Harbor cancels container execution."""
+        state_path = self.logs_dir / _STATE_FILENAME
+        try:
+            state = json.loads(state_path.read_text())
+        except (OSError, json.JSONDecodeError):
+            return
+        organization_id = self._get_env("CLOUDGENI_ORGANIZATION_ID")
+        workspace_id = self._get_env("CLOUDGENI_WORKSPACE_ID")
+        if not organization_id or not workspace_id or not self._host_api_url():
+            return
+        prefix = f"/organizations/{organization_id}/workspaces/{workspace_id}"
+        cleanup = state.get("cleanup") if isinstance(state.get("cleanup"), dict) else {}
+        session_id = state.get("sessionId")
+        if isinstance(session_id, str) and session_id:
+            cleanup["sessionDeleted"] = self._host_request(
+                "DELETE", f"{prefix}/agent-sessions/{session_id}"
+            ) in {200, 404}
+        integration_id = state.get("integrationId")
+        if isinstance(integration_id, str) and integration_id:
+            deadline = time.monotonic() + 60
+            while time.monotonic() < deadline:
+                status = self._host_request(
+                    "DELETE",
+                    f"{prefix}/integrations/{integration_id}/aws-bench-credential-lease",
+                )
+                if status in {200, 404}:
+                    cleanup["leasePurged"] = True
+                    break
+                if status != 409:
+                    break
+                time.sleep(2)
+        state["cleanup"] = cleanup
+        try:
+            state_path.write_text(json.dumps(state, indent=2, sort_keys=True) + "\n")
+        except OSError:
+            pass
+
+    def populate_context_post_run(self, context: AgentContext) -> None:
+        """Expose CloudGeni run identity and usage in Harbor's result metadata."""
+        state_path = self.logs_dir / _STATE_FILENAME
+        try:
+            state = json.loads(state_path.read_text())
+        except (OSError, json.JSONDecodeError):
+            return
+        usage = state.get("usage") if isinstance(state.get("usage"), dict) else {}
+        input_tokens = usage.get("inputTokens")
+        output_tokens = usage.get("outputTokens")
+        if isinstance(input_tokens, int):
+            context.n_input_tokens = input_tokens
+        if isinstance(output_tokens, int):
+            context.n_output_tokens = output_tokens
+        context.metadata = {
+            **(context.metadata or {}),
+            "cloudgeniSessionId": state.get("sessionId"),
+            "cloudgeniRunId": state.get("cloudgeniRunId"),
+            "cloudgeniStatus": state.get("status"),
+            "cloudgeniCleanup": state.get("cleanup"),
+        }

--- a/aws_bench/agents/cloudgeni_runner.py
+++ b/aws_bench/agents/cloudgeni_runner.py
@@ -1,0 +1,385 @@
+"""In-container bridge from an aws-bench trial to a CloudGeni agent session.
+
+This file is uploaded into the isolated Harbor environment by ``CloudGeniAgent``.
+It deliberately uses only the Python standard library so the adapter adds no
+runtime dependency to task images.
+"""
+
+from __future__ import annotations
+
+import configparser
+import json
+import os
+import re
+import signal
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+_PROMPT_PATH = Path("/installed-agent/cloudgeni-prompt.txt")
+_LOGS_DIR = Path("/logs/agent")
+_OUTPUT_TEXT_PATH = _LOGS_DIR / "agent-output.txt"
+_OUTPUT_JSON_PATH = _LOGS_DIR / "agent-output.json"
+_STATE_PATH = _LOGS_DIR / "cloudgeni-state.json"
+_TERMINAL_STATUSES = {"COMPLETED", "FAILED", "CANCELLED"}
+_REQUIRED_ENV = (
+    "CLOUDGENI_API_URL",
+    "CLOUDGENI_API_KEY",
+    "CLOUDGENI_ORGANIZATION_ID",
+    "CLOUDGENI_WORKSPACE_ID",
+)
+
+
+class BridgeError(RuntimeError):
+    """A user-safe bridge failure."""
+
+
+def _required_env(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise BridgeError(f"Missing required environment variable: {name}")
+    return value
+
+
+def _api_root(value: str) -> str:
+    root = value.rstrip("/")
+    return root if root.endswith("/api/v1") else f"{root}/api/v1"
+
+
+def _request(
+    method: str,
+    path: str,
+    *,
+    payload: dict[str, Any] | None = None,
+    accepted_statuses: set[int] | None = None,
+) -> tuple[int, dict[str, Any]]:
+    api_url = _api_root(_required_env("CLOUDGENI_API_URL"))
+    body = json.dumps(payload).encode() if payload is not None else None
+    request = urllib.request.Request(
+        f"{api_url}{path}",
+        data=body,
+        method=method,
+        headers={
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "X-CLOUDGENI-API-KEY": _required_env("CLOUDGENI_API_KEY"),
+        },
+    )
+    accepted = accepted_statuses or {200, 201}
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            status = response.status
+            raw = response.read()
+    except urllib.error.HTTPError as error:
+        status = error.code
+        raw = error.read()
+    except urllib.error.URLError as error:
+        raise BridgeError(f"CloudGeni API request failed: {error.reason}") from error
+
+    try:
+        decoded = json.loads(raw) if raw else {}
+    except json.JSONDecodeError:
+        decoded = {}
+    if status not in accepted:
+        message = decoded.get("message") or decoded.get("error") or f"HTTP {status}"
+        if isinstance(message, dict):
+            message = message.get("message") or message.get("code") or f"HTTP {status}"
+        raise BridgeError(f"CloudGeni API request failed ({status}): {message}")
+    return status, decoded
+
+
+def _credentials() -> dict[str, str]:
+    profile = os.environ.get("AWS_PROFILE", "default")
+    credentials_path = Path(
+        os.path.expandvars(os.environ.get("AWS_SHARED_CREDENTIALS_FILE", "$HOME/.aws/credentials"))
+    ).expanduser()
+    parser = configparser.RawConfigParser()
+    if not parser.read(credentials_path):
+        raise BridgeError("AWS-Bench credential file is unavailable")
+    if not parser.has_section(profile):
+        raise BridgeError(f"AWS-Bench credential profile is unavailable: {profile}")
+
+    values = {
+        "accessKeyId": parser.get(profile, "aws_access_key_id", fallback="").strip(),
+        "secretAccessKey": parser.get(profile, "aws_secret_access_key", fallback="").strip(),
+        "sessionToken": parser.get(profile, "aws_session_token", fallback="").strip(),
+    }
+    if not all(values.values()):
+        raise BridgeError("AWS-Bench supplied an incomplete temporary credential profile")
+    if not values["accessKeyId"].startswith("ASIA"):
+        raise BridgeError("CloudGeni benchmark trials require temporary ASIA credentials")
+    return values
+
+
+def _caller_account_id() -> str:
+    profile = os.environ.get("AWS_PROFILE", "default")
+    region = os.environ.get("AWS_REGION", "us-east-1")
+    try:
+        result = subprocess.run(
+            [
+                "aws",
+                "sts",
+                "get-caller-identity",
+                "--profile",
+                profile,
+                "--region",
+                region,
+                "--output",
+                "json",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        account_id = json.loads(result.stdout).get("Account", "")
+    except (OSError, subprocess.SubprocessError, json.JSONDecodeError) as error:
+        raise BridgeError("Unable to verify the AWS-Bench trial identity") from error
+    if not re.fullmatch(r"\d{12}", account_id):
+        raise BridgeError("AWS STS returned an invalid account identity")
+    return account_id
+
+
+def _workspace_path(suffix: str) -> str:
+    organization_id = _required_env("CLOUDGENI_ORGANIZATION_ID")
+    workspace_id = _required_env("CLOUDGENI_WORKSPACE_ID")
+    return f"/organizations/{organization_id}/workspaces/{workspace_id}{suffix}"
+
+
+def _write_state(state: dict[str, Any]) -> None:
+    _LOGS_DIR.mkdir(parents=True, exist_ok=True)
+    temporary_path = _STATE_PATH.with_suffix(".tmp")
+    temporary_path.write_text(json.dumps(state, indent=2, sort_keys=True))
+    temporary_path.replace(_STATE_PATH)
+
+
+def _create_lease(run_id: str, account_id: str, credentials: dict[str, str]) -> str:
+    region = os.environ.get("AWS_REGION", "us-east-1")
+    lease_seconds = int(os.environ.get("CLOUDGENI_AWS_BENCH_LEASE_SECONDS", "3500"))
+    if not 120 <= lease_seconds <= 3600:
+        raise BridgeError("CLOUDGENI_AWS_BENCH_LEASE_SECONDS must be between 120 and 3600")
+    expires_at = datetime.now(UTC) + timedelta(seconds=lease_seconds)
+    _, response = _request(
+        "POST",
+        _workspace_path("/integrations?method=aws-bench-credential-lease"),
+        payload={
+            "name": f"AWS-Bench {run_id}",
+            "description": "Ephemeral AWS-Bench trial credential; purge after this run.",
+            "type": "CLOUD",
+            "provider": "AWS",
+            "benchmarkRunId": run_id,
+            "providerConfig": {"accountId": account_id, "defaultRegion": region},
+            "credential": {
+                "name": f"AWS-Bench {run_id}",
+                **credentials,
+                "expiresAt": expires_at.isoformat().replace("+00:00", "Z"),
+            },
+        },
+    )
+    integration_id = response.get("data", {}).get("id")
+    if not isinstance(integration_id, str) or not integration_id:
+        raise BridgeError("CloudGeni did not return a credential lease ID")
+    return integration_id
+
+
+def _create_session(run_id: str, integration_id: str, instruction: str) -> tuple[str, str]:
+    bridge_instruction = (
+        f"{instruction.rstrip()}\n\n"
+        "CloudGeni bridge note: /logs/agent is owned by AWS-Bench and is not mounted in "
+        "your sandbox. Return the exact intended file contents as your final response; "
+        "the bridge will write that response to the requested AWS-Bench output path."
+    )
+    _, response = _request(
+        "POST",
+        _workspace_path("/agent-sessions"),
+        payload={
+            "idempotencyKey": f"aws-bench:{run_id}",
+            "agentSlug": "aws-bench",
+            "prompt": bridge_instruction,
+            "cloudIntegrationIds": [integration_id],
+        },
+    )
+    data = response.get("data", {})
+    session_id = data.get("sessionId")
+    cloudgeni_run_id = data.get("runId")
+    if not isinstance(session_id, str) or not isinstance(cloudgeni_run_id, str):
+        raise BridgeError("CloudGeni did not return an agent session identity")
+    return session_id, cloudgeni_run_id
+
+
+def _wait_for_session(session_id: str, timeout_seconds: int) -> dict[str, Any]:
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        _, response = _request("GET", _workspace_path(f"/agent-sessions/{session_id}"))
+        state = response.get("data", {})
+        status = state.get("latestRun", {}).get("status")
+        if status in _TERMINAL_STATUSES:
+            return state
+        time.sleep(2)
+    raise BridgeError(f"CloudGeni agent did not finish within {timeout_seconds} seconds")
+
+
+def _text_from_part(part: Any) -> str:
+    if not isinstance(part, dict):
+        return ""
+    text = part.get("text")
+    if isinstance(text, str):
+        return text
+    output = part.get("output")
+    if isinstance(output, str):
+        return output
+    return ""
+
+
+def _result_output(session: dict[str, Any]) -> str:
+    result = session.get("latestRun", {}).get("result")
+    if not isinstance(result, dict):
+        return ""
+    output = result.get("output")
+    return output.strip() if isinstance(output, str) else ""
+
+
+def _final_assistant_text(session_id: str, session: dict[str, Any] | None = None) -> str:
+    output = _result_output(session or {})
+    if output:
+        return output
+    deadline = time.monotonic() + 30
+    while time.monotonic() < deadline:
+        _, response = _request("GET", _workspace_path(f"/agent-sessions/{session_id}/messages"))
+        messages = response.get("data", {}).get("messages", [])
+        for message in reversed(messages):
+            if message.get("role") != "assistant":
+                continue
+            text = "".join(_text_from_part(part) for part in message.get("parts", [])).strip()
+            if text:
+                return text
+        time.sleep(2)
+    raise BridgeError("CloudGeni completed without a projected assistant response")
+
+
+def _extract_json(text: str) -> Any:
+    candidates = [text.strip()]
+    candidates.extend(
+        match.group(1).strip()
+        for match in re.finditer(r"```(?:json)?\s*(.*?)\s*```", text, flags=re.DOTALL)
+    )
+    for candidate in candidates:
+        try:
+            return json.loads(candidate)
+        except json.JSONDecodeError:
+            continue
+    raise BridgeError("CloudGeni did not return valid JSON for agent-output.json")
+
+
+def _write_output(instruction: str, answer: str) -> None:
+    _LOGS_DIR.mkdir(parents=True, exist_ok=True)
+    _OUTPUT_TEXT_PATH.write_text(answer.rstrip() + "\n")
+    if "/logs/agent/agent-output.json" in instruction:
+        _OUTPUT_JSON_PATH.write_text(
+            json.dumps(_extract_json(answer), separators=(",", ":")) + "\n"
+        )
+
+
+def _cleanup(session_id: str | None, integration_id: str | None) -> dict[str, bool]:
+    result = {"sessionDeleted": session_id is None, "leasePurged": integration_id is None}
+    if session_id:
+        try:
+            _request(
+                "DELETE",
+                _workspace_path(f"/agent-sessions/{session_id}"),
+                accepted_statuses={200, 404},
+            )
+            result["sessionDeleted"] = True
+        except BridgeError:
+            pass
+    if integration_id:
+        deadline = time.monotonic() + 60
+        while time.monotonic() < deadline:
+            try:
+                _request(
+                    "DELETE",
+                    _workspace_path(f"/integrations/{integration_id}/aws-bench-credential-lease"),
+                    accepted_statuses={200, 404},
+                )
+                result["leasePurged"] = True
+                break
+            except BridgeError:
+                time.sleep(2)
+    return result
+
+
+def main() -> int:
+    """Run one CloudGeni-backed AWS-Bench trial."""
+    for name in _REQUIRED_ENV:
+        _required_env(name)
+    instruction = _PROMPT_PATH.read_text()
+    run_id = f"trial-{uuid4().hex}"
+    state: dict[str, Any] = {
+        "schemaVersion": 1,
+        "benchmarkRunId": run_id,
+        "sessionId": None,
+        "cloudgeniRunId": None,
+        "integrationId": None,
+        "status": "STARTING",
+        "cleanup": {"sessionDeleted": False, "leasePurged": False},
+    }
+    _write_state(state)
+
+    def interrupt(_signum: int, _frame: Any) -> None:
+        raise InterruptedError("AWS-Bench interrupted the CloudGeni bridge")
+
+    signal.signal(signal.SIGTERM, interrupt)
+    signal.signal(signal.SIGINT, interrupt)
+
+    try:
+        credentials = _credentials()
+        account_id = _caller_account_id()
+        integration_id = _create_lease(run_id, account_id, credentials)
+        state["integrationId"] = integration_id
+        state["status"] = "LEASE_CREATED"
+        _write_state(state)
+
+        session_id, cloudgeni_run_id = _create_session(run_id, integration_id, instruction)
+        state.update(
+            {
+                "sessionId": session_id,
+                "cloudgeniRunId": cloudgeni_run_id,
+                "status": "RUNNING",
+            }
+        )
+        _write_state(state)
+
+        timeout_seconds = int(os.environ.get("CLOUDGENI_AWS_BENCH_TIMEOUT_SECONDS", "3300"))
+        if not 30 <= timeout_seconds <= 3480:
+            raise BridgeError("CLOUDGENI_AWS_BENCH_TIMEOUT_SECONDS must be between 30 and 3480")
+        session = _wait_for_session(session_id, timeout_seconds)
+        status = session.get("latestRun", {}).get("status")
+        state["status"] = status
+        state["usage"] = {
+            "inputTokens": session.get("totalInputTokens"),
+            "outputTokens": session.get("totalOutputTokens"),
+            "modelTokens": session.get("modelTokenUsage"),
+        }
+        _write_state(state)
+        if status != "COMPLETED":
+            raise BridgeError(f"CloudGeni agent ended with status {status}")
+        _write_output(instruction, _final_assistant_text(session_id, session))
+        return 0
+    except (BridgeError, InterruptedError, ValueError) as error:
+        state["status"] = "BRIDGE_FAILED"
+        state["error"] = str(error)
+        _OUTPUT_TEXT_PATH.write_text(f"CloudGeni bridge failed: {error}\n")
+        return 1
+    finally:
+        state["cleanup"] = _cleanup(state.get("sessionId"), state.get("integrationId"))
+        _write_state(state)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/aws_bench/agents/codex.py
+++ b/aws_bench/agents/codex.py
@@ -1,4 +1,4 @@
-"""Bedrock-aware Codex agent for aws-bench.
+"""Bedrock- and Azure-aware Codex agent for aws-bench.
 
 Harbor's built-in ``Codex`` agent only knows how to talk to OpenAI: it writes
 ``OPENAI_API_KEY`` into the container and runs ``codex exec`` with no provider
@@ -11,9 +11,10 @@ against Amazon Bedrock, two things are missing, and this subclass fills both:
 2. The Bedrock auth env (``AWS_BEARER_TOKEN_BEDROCK`` + ``AWS_REGION``) must be
    forwarded from the host into the codex subprocess. Harbor's Codex does not.
 
-Bedrock mode is auto-detected from a non-empty ``AWS_BEARER_TOKEN_BEDROCK`` in
-the environment. When that token is absent this behaves exactly like harbor's
-Codex (OpenAI auth).
+Bedrock mode is auto-detected from a non-empty ``AWS_BEARER_TOKEN_BEDROCK``.
+Azure mode is selected when both ``AZURE_OPENAI_ENDPOINT`` and
+``AZURE_OPENAI_API_KEY`` are present. When neither is configured this behaves
+exactly like harbor's Codex (OpenAI auth).
 
 Region: pass it with ``-ae AWS_REGION=us-east-2`` (API-key auth requires a
 Region). The host ``AWS_REGION`` is auto-forwarded as a fallback.
@@ -23,6 +24,7 @@ from __future__ import annotations
 
 import os
 import shlex
+from urllib.parse import urlsplit
 
 from harbor.agents.installed.codex import Codex as _HarborCodex
 from harbor.environments.base import BaseEnvironment
@@ -32,7 +34,7 @@ _DEFAULT_AWS_REGION = "us-east-2"
 
 
 class Codex(_HarborCodex):
-    """Codex agent that can target Amazon Bedrock in addition to OpenAI."""
+    """Codex agent that can target Azure OpenAI or Bedrock in addition to OpenAI."""
 
     @staticmethod
     def _is_bedrock_mode() -> bool:
@@ -67,6 +69,47 @@ class Codex(_HarborCodex):
         # Bedrock requires a Region. Honor -ae / host AWS_REGION, else default.
         self._extra_env.setdefault("AWS_REGION", os.environ.get("AWS_REGION", _DEFAULT_AWS_REGION))
 
+    def _azure_settings(self) -> tuple[str, str] | None:
+        """Resolve an Azure OpenAI endpoint/key pair from agent or host env."""
+        endpoint = (self._get_env("AZURE_OPENAI_ENDPOINT") or "").strip().rstrip("/")
+        api_key = (self._get_env("AZURE_OPENAI_API_KEY") or "").strip()
+        if not endpoint and not api_key:
+            return None
+        if not endpoint or not api_key:
+            raise ValueError(
+                "Azure Codex requires both AZURE_OPENAI_ENDPOINT and AZURE_OPENAI_API_KEY"
+            )
+        parsed = urlsplit(endpoint)
+        if parsed.scheme != "https" or not parsed.netloc or parsed.query or parsed.fragment:
+            raise ValueError("AZURE_OPENAI_ENDPOINT must be an HTTPS Azure resource endpoint")
+        return endpoint, api_key
+
+    def _inject_azure_env(self, api_key: str) -> None:
+        """Forward the Azure API key only through the process environment."""
+        self._extra_env.setdefault("AZURE_OPENAI_API_KEY", api_key)
+
+    async def _write_azure_provider_config(
+        self, environment: BaseEnvironment, endpoint: str
+    ) -> None:
+        """Configure Codex's Responses provider for Azure OpenAI's v1 API."""
+        remote_codex_home = self._REMOTE_CODEX_HOME.as_posix()
+        provider_block = (
+            'model_provider = "azure_openai"\n'
+            "[model_providers.azure_openai]\n"
+            'name = "Azure OpenAI"\n'
+            f'base_url = "{endpoint}/openai/v1"\n'
+            'wire_api = "responses"\n'
+            'env_http_headers = { "api-key" = "AZURE_OPENAI_API_KEY" }\n'
+        )
+        await self.exec_as_agent(
+            environment,
+            command=(
+                f'mkdir -p "$CODEX_HOME" && '
+                f'echo {shlex.quote(provider_block)} >> "$CODEX_HOME/config.toml"'
+            ),
+            env={"CODEX_HOME": remote_codex_home},
+        )
+
     async def _write_bedrock_provider_config(self, environment: BaseEnvironment) -> None:
         """Write ``model_provider = "amazon-bedrock"`` into the container config.
 
@@ -93,12 +136,20 @@ class Codex(_HarborCodex):
     async def run(
         self, instruction: str, environment: BaseEnvironment, context: AgentContext
     ) -> None:
-        """Run the task, configuring Bedrock first when in Bedrock mode.
+        """Run the task, configuring a selected non-OpenAI provider first.
 
-        In Bedrock mode, forward auth env and write the provider config, then
-        defer to harbor's run (which appends the rest of config.toml).
+        Provider config is written before harbor's run, which appends the rest
+        of config.toml. Azure and Bedrock are mutually exclusive.
         """
-        if self._is_bedrock_mode():
+        azure = self._azure_settings()
+        bedrock = self._is_bedrock_mode()
+        if azure and bedrock:
+            raise ValueError("Configure only one Codex provider: Azure OpenAI or Amazon Bedrock")
+        if azure:
+            endpoint, api_key = azure
+            self._inject_azure_env(api_key)
+            await self._write_azure_provider_config(environment, endpoint)
+        elif bedrock:
             self._inject_bedrock_env()
             await self._write_bedrock_provider_config(environment)
         # super().run is decorated with @with_prompt_template; do not re-decorate.

--- a/docs/cloudgeni.md
+++ b/docs/cloudgeni.md
@@ -1,0 +1,98 @@
+# Running CloudGeni on AWS-Bench
+
+The CloudGeni adapter delegates each AWS-Bench trial to the `aws-bench` CloudGeni
+persona while preserving AWS-Bench's account isolation, reset, verifier, and
+scoring lifecycle. The generic control is AWS-Bench's built-in Codex agent using
+the same Azure OpenAI endpoint, deployment, `gpt-5.6-sol` model, and medium
+reasoning effort.
+
+## Prerequisites
+
+- Complete the normal [AWS-Bench quickstart](getting-started.md), including
+  `env init` and `env setup` for `aws-bench-quickstart`.
+- Run a CloudGeni deployment containing the AWS-Bench credential lease support,
+  with `CLOUDGENI_AWS_BENCH_ENABLED=true` and the `aws-bench` AgentConfig seeded.
+- Create an organization API key. Its creator must remain an active organization
+  and workspace member because that identity owns and can cancel the agent session.
+- Make the CloudGeni API reachable from the Harbor trial containers. For a local
+  Docker deployment, use `host.docker.internal` and the worktree's published API
+  port.
+- Set `AZURE_OPENAI_ENDPOINT`, `AZURE_OPENAI_API_KEY`, and the Azure deployment
+  name for the generic Codex control. Read-only tasks also need the normal
+  verifier model credential described in the AWS-Bench guide.
+
+Never put a CloudGeni API key directly in a committed command, config, or result
+artifact. The examples below use shell variables intentionally.
+
+## CloudGeni run
+
+Use the same dataset, task filter, attempt count, timeout multipliers, and verifier
+environment for both arms. Start with `-n 1`; raise concurrency only after the
+credential lease and session cleanup fields are green in every trial's
+`agent/cloudgeni-state.json`.
+
+```bash
+uv run aws-bench run \
+  --env-name awsbench-env \
+  -d aws-bench-quickstart \
+  --agent-import-path aws_bench.agents.cloudgeni:CloudGeniAgent \
+  --job-name cloudgeni-quickstart \
+  --ae "CLOUDGENI_API_URL=$CLOUDGENI_CONTAINER_API_URL" \
+  --ae "CLOUDGENI_HOST_API_URL=$CLOUDGENI_HOST_API_URL" \
+  --ae "CLOUDGENI_API_KEY=$CLOUDGENI_API_KEY" \
+  --ae "CLOUDGENI_ORGANIZATION_ID=$CLOUDGENI_ORGANIZATION_ID" \
+  --ae "CLOUDGENI_WORKSPACE_ID=$CLOUDGENI_WORKSPACE_ID" \
+  --ae CLOUDGENI_AWS_BENCH_TIMEOUT_SECONDS=270 \
+  --ve "AWS_BEARER_TOKEN_BEDROCK=$AWS_BEARER_TOKEN_BEDROCK" \
+  -n 1 \
+  --yes
+```
+
+The adapter reads AWS-Bench's temporary `ASIA...` profile inside the isolated
+trial container, verifies the account with STS, creates a time-limited CloudGeni
+credential lease, starts the dedicated persona, copies the final response to the
+requested `/logs/agent/agent-output.*` file, cancels/deletes the session, and
+hard-purges the encrypted credential row. A host-side `finally` repeats cleanup
+if Harbor cancels the in-container process.
+
+## Generic direct-agent control
+
+```bash
+uv run aws-bench run \
+  --env-name awsbench-env \
+  -d aws-bench-quickstart \
+  -a codex \
+  -m "$AZURE_OPENAI_DEPLOYMENT" \
+  --ak reasoning_effort=medium \
+  --job-name generic-codex-quickstart \
+  --ae "AZURE_OPENAI_ENDPOINT=$AZURE_OPENAI_ENDPOINT" \
+  --ae "AZURE_OPENAI_API_KEY=$AZURE_OPENAI_API_KEY" \
+  --ve "AWS_BEARER_TOKEN_BEDROCK=$AWS_BEARER_TOKEN_BEDROCK" \
+  -n 1 \
+  --yes
+```
+
+Codex is the useful generic control because a text-only one-shot model call cannot
+inspect or mutate the isolated AWS account. This control gives the same model a
+generic shell/tool loop without CloudGeni's persona, capability broker, session
+runtime, or product context.
+
+## Compare and clean up
+
+```bash
+uv run python scripts/compare_runs.py \
+  jobs/cloudgeni-quickstart \
+  jobs/generic-codex-quickstart \
+  --output jobs/quickstart-comparison.md \
+  --json-output jobs/quickstart-comparison.json
+
+uv run aws-bench env cleanup \
+  --env-name awsbench-env \
+  -d aws-bench-quickstart \
+  --yes
+```
+
+Before accepting a result, confirm every CloudGeni trial state says both
+`sessionDeleted: true` and `leasePurged: true`, the two jobs contain the same
+task/attempt pairs, and neither job has infrastructure exceptions. Compare pass
+rate and paired reward first; latency, tokens, and cost are secondary diagnostics.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -262,6 +262,9 @@ Common flags:
 
 ## Checking results
 
+To run CloudGeni and a same-model generic Codex control against the same tasks,
+see [Running CloudGeni on AWS-Bench](cloudgeni.md).
+
 Results land in `jobs/<timestamp>/` under the package directory. For each trial:
 
 | File | Contents |

--- a/scripts/compare_runs.py
+++ b/scripts/compare_runs.py
@@ -1,0 +1,177 @@
+"""Create a paired CloudGeni-versus-baseline AWS-Bench comparison.
+
+Usage:
+    uv run python scripts/compare_runs.py jobs/cloudgeni jobs/generic-codex \
+      --output jobs/comparison.md --json-output jobs/comparison.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+from aws_bench.metrics.aggregation import aggregate_basic
+from aws_bench.metrics.run_data import RunData, TrialData
+
+
+def _load(path: Path) -> RunData:
+    run = RunData.load(path)
+    if run is None or not run.trials:
+        raise ValueError(f"No completed AWS-Bench run found at {path}")
+    return run
+
+
+def _attempts(run: RunData) -> dict[tuple[str, int], TrialData]:
+    counts: dict[str, int] = defaultdict(int)
+    result: dict[tuple[str, int], TrialData] = {}
+    for trial in run.trials:
+        counts[trial.task_name] += 1
+        result[(trial.task_name, counts[trial.task_name])] = trial
+    return result
+
+
+def _mean(values: list[float]) -> float | None:
+    return statistics.mean(values) if values else None
+
+
+def _summary(run: RunData, *, fallback_agent: str) -> dict[str, Any]:
+    basic = aggregate_basic(run)
+    latencies = [trial.latency_sec for trial in run.trials if trial.latency_sec is not None]
+    rewards = [trial.reward for trial in run.trials if trial.reward is not None]
+    return {
+        "runDirectory": str(run.run_dir),
+        "agent": run.agent_name or fallback_agent,
+        "model": run.model_name,
+        "provider": run.model_provider,
+        "trials": len(run.trials),
+        "scoredTrials": len(rewards),
+        "passRate": (
+            sum(1 for reward in rewards if reward >= 1.0) / len(rewards) if rewards else None
+        ),
+        "meanReward": _mean(rewards),
+        "meanAgentLatencySeconds": _mean(latencies),
+        "metrics": basic,
+    }
+
+
+def compare(cloudgeni: RunData, baseline: RunData) -> dict[str, Any]:
+    """Return run summaries plus paired per-task outcomes."""
+    cloudgeni_attempts = _attempts(cloudgeni)
+    baseline_attempts = _attempts(baseline)
+    keys = sorted(set(cloudgeni_attempts) | set(baseline_attempts))
+    paired = []
+    for task_name, attempt in keys:
+        cloudgeni_trial = cloudgeni_attempts.get((task_name, attempt))
+        baseline_trial = baseline_attempts.get((task_name, attempt))
+        cloudgeni_reward = cloudgeni_trial.reward if cloudgeni_trial else None
+        baseline_reward = baseline_trial.reward if baseline_trial else None
+        paired.append(
+            {
+                "task": task_name,
+                "attempt": attempt,
+                "cloudgeniReward": cloudgeni_reward,
+                "baselineReward": baseline_reward,
+                "rewardDelta": (
+                    cloudgeni_reward - baseline_reward
+                    if cloudgeni_reward is not None and baseline_reward is not None
+                    else None
+                ),
+                "cloudgeniLatencySeconds": (
+                    cloudgeni_trial.latency_sec if cloudgeni_trial else None
+                ),
+                "baselineLatencySeconds": baseline_trial.latency_sec if baseline_trial else None,
+                "cloudgeniException": (
+                    cloudgeni_trial.exception_type if cloudgeni_trial else "missing trial"
+                ),
+                "baselineException": (
+                    baseline_trial.exception_type if baseline_trial else "missing trial"
+                ),
+            }
+        )
+    return {
+        "schemaVersion": 1,
+        "cloudgeni": _summary(cloudgeni, fallback_agent="CloudGeni"),
+        "genericBaseline": _summary(baseline, fallback_agent="Generic Codex"),
+        "pairedTrials": paired,
+    }
+
+
+def _display(value: Any, *, percent: bool = False) -> str:
+    if value is None:
+        return "n/a"
+    if isinstance(value, float):
+        return f"{value:.1%}" if percent else f"{value:.3f}"
+    return str(value)
+
+
+def _markdown(comparison: dict[str, Any]) -> str:
+    cloudgeni = comparison["cloudgeni"]
+    baseline = comparison["genericBaseline"]
+    lines = [
+        "# AWS-Bench comparison",
+        "",
+        "| Metric | CloudGeni | Generic baseline |",
+        "| --- | ---: | ---: |",
+        f"| Agent | {cloudgeni['agent']} | {baseline['agent']} |",
+        f"| Model | {cloudgeni['model'] or 'CloudGeni deployment'} | {baseline['model']} |",
+        f"| Trials | {cloudgeni['trials']} | {baseline['trials']} |",
+        (
+            f"| Pass rate | {_display(cloudgeni['passRate'], percent=True)} | "
+            f"{_display(baseline['passRate'], percent=True)} |"
+        ),
+        (
+            f"| Mean reward | {_display(cloudgeni['meanReward'])} | "
+            f"{_display(baseline['meanReward'])} |"
+        ),
+        (
+            f"| Mean agent latency (s) | {_display(cloudgeni['meanAgentLatencySeconds'])} | "
+            f"{_display(baseline['meanAgentLatencySeconds'])} |"
+        ),
+        "",
+        "## Paired trials",
+        "",
+        "| Task | Attempt | CloudGeni | Baseline | Delta |",
+        "| --- | ---: | ---: | ---: | ---: |",
+    ]
+    for trial in comparison["pairedTrials"]:
+        lines.append(
+            f"| {trial['task']} | {trial['attempt']} | "
+            f"{_display(trial['cloudgeniReward'])} | {_display(trial['baselineReward'])} | "
+            f"{_display(trial['rewardDelta'])} |"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the comparison CLI parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("cloudgeni_run", type=Path)
+    parser.add_argument("baseline_run", type=Path)
+    parser.add_argument("--output", type=Path, default=Path("aws-bench-comparison.md"))
+    parser.add_argument("--json-output", type=Path, default=Path("aws-bench-comparison.json"))
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Load two completed jobs and write paired reports."""
+    args = build_parser().parse_args(argv)
+    try:
+        comparison = compare(_load(args.cloudgeni_run), _load(args.baseline_run))
+    except ValueError as error:
+        print(error, file=sys.stderr)
+        return 1
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.json_output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(_markdown(comparison))
+    args.json_output.write_text(json.dumps(comparison, indent=2, sort_keys=True) + "\n")
+    print(f"Wrote {args.output} and {args.json_output}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/agents/test_cloudgeni.py
+++ b/tests/agents/test_cloudgeni.py
@@ -1,0 +1,134 @@
+"""Tests for the CloudGeni Harbor adapter."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from harbor.agents.installed.base import NonZeroAgentExitCodeError
+
+from aws_bench.agents.cloudgeni import CloudGeniAgent
+
+
+@pytest.fixture
+def logs_dir(tmp_path: Path) -> Path:
+    return tmp_path / "logs"
+
+
+@pytest.fixture
+def configured_agent(logs_dir: Path) -> CloudGeniAgent:
+    return CloudGeniAgent(
+        logs_dir=logs_dir,
+        extra_env={
+            "CLOUDGENI_API_URL": "https://api.example.com",
+            "CLOUDGENI_API_KEY": "cgk_test_secret",
+            "CLOUDGENI_ORGANIZATION_ID": "org_test",
+            "CLOUDGENI_WORKSPACE_ID": "ws_test",
+        },
+    )
+
+
+def _environment(return_codes: list[int] | None = None) -> MagicMock:
+    codes = iter(return_codes or [0, 0, 0])
+    environment = MagicMock()
+    environment.exec = AsyncMock(
+        side_effect=lambda **_kwargs: MagicMock(return_code=next(codes), stdout="", stderr="")
+    )
+    return environment
+
+
+def test_name() -> None:
+    assert CloudGeniAgent.name() == "cloudgeni"
+
+
+@pytest.mark.asyncio
+async def test_setup_uploads_standard_library_runner(configured_agent: CloudGeniAgent) -> None:
+    environment = _environment([0, 0])
+
+    await configured_agent.setup(environment)
+
+    commands = [call.kwargs["command"] for call in environment.exec.call_args_list]
+    assert "command -v python3" in commands[0]
+    assert "cloudgeni_runner.py" in commands[1]
+    assert "cgk_test_secret" not in "".join(commands)
+
+
+@pytest.mark.asyncio
+async def test_run_requires_configuration(logs_dir: Path) -> None:
+    agent = CloudGeniAgent(logs_dir=logs_dir)
+
+    with pytest.raises(ValueError, match="CLOUDGENI_API_KEY"):
+        await agent.run("Do the task", _environment(), MagicMock())
+
+
+@pytest.mark.asyncio
+async def test_run_passes_secrets_only_as_environment(
+    configured_agent: CloudGeniAgent,
+) -> None:
+    environment = _environment([0, 0])
+
+    with patch.object(configured_agent, "_host_cleanup"):
+        await configured_agent.run("Do the task", environment, MagicMock())
+
+    run_call = environment.exec.call_args_list[1]
+    assert run_call.kwargs["command"] == "python3 /installed-agent/cloudgeni_runner.py"
+    assert run_call.kwargs["env"]["CLOUDGENI_API_KEY"] == "cgk_test_secret"
+    assert "cgk_test_secret" not in run_call.kwargs["command"]
+
+
+@pytest.mark.asyncio
+async def test_run_cleans_up_after_bridge_failure(configured_agent: CloudGeniAgent) -> None:
+    environment = _environment([0, 1])
+
+    with patch.object(configured_agent, "_host_cleanup") as cleanup:
+        with pytest.raises(NonZeroAgentExitCodeError):
+            await configured_agent.run("Do the task", environment, MagicMock())
+
+    cleanup.assert_called_once()
+
+
+def test_host_cleanup_cancels_session_before_purging_lease(
+    configured_agent: CloudGeniAgent, logs_dir: Path
+) -> None:
+    logs_dir.mkdir(parents=True)
+    (logs_dir / "cloudgeni-state.json").write_text(
+        json.dumps({"sessionId": "sess_1", "integrationId": "int_1"})
+    )
+
+    with patch.object(configured_agent, "_host_request", return_value=200) as request:
+        configured_agent._host_cleanup()
+
+    assert request.call_args_list[0].args == (
+        "DELETE",
+        "/organizations/org_test/workspaces/ws_test/agent-sessions/sess_1",
+    )
+    assert request.call_args_list[1].args == (
+        "DELETE",
+        "/organizations/org_test/workspaces/ws_test/integrations/int_1/aws-bench-credential-lease",
+    )
+    state = json.loads((logs_dir / "cloudgeni-state.json").read_text())
+    assert state["cleanup"] == {"sessionDeleted": True, "leasePurged": True}
+
+
+def test_populate_context_reads_usage(configured_agent: CloudGeniAgent, logs_dir: Path) -> None:
+    logs_dir.mkdir(parents=True)
+    (logs_dir / "cloudgeni-state.json").write_text(
+        json.dumps(
+            {
+                "sessionId": "sess_1",
+                "cloudgeniRunId": "run_1",
+                "status": "COMPLETED",
+                "cleanup": {"sessionDeleted": True, "leasePurged": True},
+                "usage": {"inputTokens": 123, "outputTokens": 45},
+            }
+        )
+    )
+    context = MagicMock(n_input_tokens=None, n_output_tokens=None, metadata=None)
+
+    configured_agent.populate_context_post_run(context)
+
+    assert context.n_input_tokens == 123
+    assert context.n_output_tokens == 45
+    assert context.metadata["cloudgeniStatus"] == "COMPLETED"

--- a/tests/agents/test_cloudgeni_runner.py
+++ b/tests/agents/test_cloudgeni_runner.py
@@ -1,0 +1,178 @@
+"""Unit tests for the standard-library CloudGeni container bridge."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from aws_bench.agents import cloudgeni_runner as runner
+
+
+@pytest.fixture
+def bridge_paths(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    logs = tmp_path / "logs"
+    monkeypatch.setattr(runner, "_PROMPT_PATH", tmp_path / "prompt.txt")
+    monkeypatch.setattr(runner, "_LOGS_DIR", logs)
+    monkeypatch.setattr(runner, "_OUTPUT_TEXT_PATH", logs / "agent-output.txt")
+    monkeypatch.setattr(runner, "_OUTPUT_JSON_PATH", logs / "agent-output.json")
+    monkeypatch.setattr(runner, "_STATE_PATH", logs / "cloudgeni-state.json")
+    runner._PROMPT_PATH.write_text("Return JSON to /logs/agent/agent-output.json")
+    return logs
+
+
+@pytest.fixture(autouse=True)
+def bridge_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    values = {
+        "CLOUDGENI_API_URL": "https://api.example.com",
+        "CLOUDGENI_API_KEY": "cgk_test_secret",
+        "CLOUDGENI_ORGANIZATION_ID": "org_test",
+        "CLOUDGENI_WORKSPACE_ID": "ws_test",
+        "AWS_REGION": "us-west-2",
+        "AWS_PROFILE": "trial",
+    }
+    for name, value in values.items():
+        monkeypatch.setenv(name, value)
+
+
+def test_api_root_normalizes_version() -> None:
+    assert runner._api_root("https://api.example.com/") == "https://api.example.com/api/v1"
+    assert runner._api_root("https://api.example.com/api/v1") == ("https://api.example.com/api/v1")
+
+
+def test_credentials_reads_temporary_profile(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    credentials_path = tmp_path / "credentials"
+    credentials_path.write_text(
+        "[trial]\n"
+        "aws_access_key_id=ASIAABCDEFGHIJKLMNOP\n"
+        "aws_secret_access_key=abcdefghijklmnopqrstuvwxyz0123456789ABCD\n"
+        "aws_session_token=temporary-session-token\n"
+    )
+    monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", str(credentials_path))
+
+    values = runner._credentials()
+
+    assert values["accessKeyId"] == "ASIAABCDEFGHIJKLMNOP"
+    assert values["sessionToken"] == "temporary-session-token"
+
+
+def test_credentials_rejects_static_key(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    credentials_path = tmp_path / "credentials"
+    credentials_path.write_text(
+        "[trial]\n"
+        "aws_access_key_id=AKIAABCDEFGHIJKLMNOP\n"
+        "aws_secret_access_key=abcdefghijklmnopqrstuvwxyz0123456789ABCD\n"
+        "aws_session_token=temporary-session-token\n"
+    )
+    monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", str(credentials_path))
+
+    with pytest.raises(runner.BridgeError, match="temporary ASIA"):
+        runner._credentials()
+
+
+def test_caller_account_id_uses_scoped_profile() -> None:
+    completed = MagicMock(stdout='{"Account":"123456789012"}')
+
+    with patch.object(runner.subprocess, "run", return_value=completed) as run:
+        assert runner._caller_account_id() == "123456789012"
+
+    assert run.call_args.args[0][0:4] == ["aws", "sts", "get-caller-identity", "--profile"]
+    assert "trial" in run.call_args.args[0]
+
+
+def test_write_output_extracts_fenced_json(bridge_paths: Path) -> None:
+    runner._write_output(
+        "Write /logs/agent/agent-output.json",
+        'Result:\n```json\n{"resourceId":"r-1"}\n```',
+    )
+
+    assert json.loads((bridge_paths / "agent-output.json").read_text()) == {"resourceId": "r-1"}
+    assert "Result:" in (bridge_paths / "agent-output.txt").read_text()
+
+
+def test_final_assistant_text_reads_projected_message() -> None:
+    response = {
+        "data": {
+            "messages": [
+                {"role": "user", "parts": [{"type": "text", "text": "prompt"}]},
+                {
+                    "role": "assistant",
+                    "parts": [{"type": "text", "text": "final answer"}],
+                },
+            ]
+        }
+    }
+
+    with patch.object(runner, "_request", return_value=(200, response)):
+        assert runner._final_assistant_text("sess_1") == "final answer"
+
+
+def test_final_assistant_text_prefers_native_turn_result() -> None:
+    session = {
+        "latestRun": {
+            "status": "COMPLETED",
+            "result": {"output": "native final answer"},
+        }
+    }
+
+    with patch.object(runner, "_request") as request:
+        assert runner._final_assistant_text("sess_1", session) == "native final answer"
+
+    request.assert_not_called()
+
+
+def test_main_runs_session_writes_output_and_cleans_up(bridge_paths: Path) -> None:
+    session_state = {
+        "latestRun": {"status": "COMPLETED", "result": {"output": '{"ok":true}'}},
+        "totalInputTokens": 100,
+        "totalOutputTokens": 25,
+        "modelTokenUsage": 125,
+    }
+    cleanup = {"sessionDeleted": True, "leasePurged": True}
+
+    with (
+        patch.object(
+            runner,
+            "_credentials",
+            return_value={
+                "accessKeyId": "ASIAABCDEFGHIJKLMNOP",
+                "secretAccessKey": "s" * 40,
+                "sessionToken": "token",
+            },
+        ),
+        patch.object(runner, "_caller_account_id", return_value="123456789012"),
+        patch.object(runner, "_create_lease", return_value="int_1"),
+        patch.object(runner, "_create_session", return_value=("sess_1", "run_1")),
+        patch.object(runner, "_wait_for_session", return_value=session_state),
+        patch.object(runner, "_final_assistant_text", return_value='{"ok":true}'),
+        patch.object(runner, "_cleanup", return_value=cleanup) as cleanup_call,
+    ):
+        assert runner.main() == 0
+
+    state = json.loads((bridge_paths / "cloudgeni-state.json").read_text())
+    assert state["status"] == "COMPLETED"
+    assert state["cleanup"] == cleanup
+    assert json.loads((bridge_paths / "agent-output.json").read_text()) == {"ok": True}
+    cleanup_call.assert_called_once_with("sess_1", "int_1")
+
+
+def test_main_records_safe_failure_and_still_cleans_up(bridge_paths: Path) -> None:
+    with (
+        patch.object(runner, "_credentials", side_effect=runner.BridgeError("bad profile")),
+        patch.object(
+            runner,
+            "_cleanup",
+            return_value={"sessionDeleted": True, "leasePurged": True},
+        ) as cleanup,
+    ):
+        assert runner.main() == 1
+
+    state = json.loads((bridge_paths / "cloudgeni-state.json").read_text())
+    assert state["status"] == "BRIDGE_FAILED"
+    assert state["error"] == "bad profile"
+    assert "bad profile" in (bridge_paths / "agent-output.txt").read_text()
+    cleanup.assert_called_once_with(None, None)

--- a/tests/agents/test_codex.py
+++ b/tests/agents/test_codex.py
@@ -1,0 +1,84 @@
+"""Tests for the provider-aware Codex agent."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from harbor.agents.installed.codex import Codex as HarborCodex
+
+from aws_bench.agents.codex import Codex
+
+
+@pytest.fixture
+def logs_dir(tmp_path: Path) -> Path:
+    return tmp_path / "logs"
+
+
+def test_azure_settings_accept_complete_extra_env(logs_dir: Path) -> None:
+    agent = Codex(
+        logs_dir=logs_dir,
+        extra_env={
+            "AZURE_OPENAI_ENDPOINT": "https://example.openai.azure.com/",
+            "AZURE_OPENAI_API_KEY": "azure-secret",
+        },
+    )
+
+    assert agent._azure_settings() == (
+        "https://example.openai.azure.com",
+        "azure-secret",
+    )
+
+
+def test_azure_settings_reject_partial_configuration(logs_dir: Path) -> None:
+    agent = Codex(
+        logs_dir=logs_dir,
+        extra_env={"AZURE_OPENAI_ENDPOINT": "https://example.openai.azure.com"},
+    )
+
+    with pytest.raises(ValueError, match="requires both"):
+        agent._azure_settings()
+
+
+@pytest.mark.asyncio
+async def test_run_writes_azure_provider_before_harbor_run(logs_dir: Path) -> None:
+    agent = Codex(
+        logs_dir=logs_dir,
+        model_name="gpt-5.6-sol",
+        extra_env={
+            "AZURE_OPENAI_ENDPOINT": "https://example.openai.azure.com",
+            "AZURE_OPENAI_API_KEY": "azure-secret",
+        },
+    )
+    environment = MagicMock()
+    agent.exec_as_agent = AsyncMock()
+
+    with (
+        patch.object(Codex, "_is_bedrock_mode", return_value=False),
+        patch.object(HarborCodex, "run", new_callable=AsyncMock) as harbor_run,
+    ):
+        await agent.run("Do the task", environment, MagicMock())
+
+    provider_command = agent.exec_as_agent.call_args.kwargs["command"]
+    assert "azure_openai" in provider_command
+    assert "https://example.openai.azure.com/openai/v1" in provider_command
+    assert "azure-secret" not in provider_command
+    assert agent._extra_env["AZURE_OPENAI_API_KEY"] == "azure-secret"
+    harbor_run.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_run_rejects_multiple_non_openai_providers(logs_dir: Path) -> None:
+    agent = Codex(
+        logs_dir=logs_dir,
+        model_name="gpt-5.6-sol",
+        extra_env={
+            "AZURE_OPENAI_ENDPOINT": "https://example.openai.azure.com",
+            "AZURE_OPENAI_API_KEY": "azure-secret",
+        },
+    )
+
+    with patch.object(Codex, "_is_bedrock_mode", return_value=True):
+        with pytest.raises(ValueError, match="only one Codex provider"):
+            await agent.run("Do the task", MagicMock(), MagicMock())


### PR DESCRIPTION
## Summary

- add a Harbor-compatible CloudGeni agent adapter
- run the in-container bridge with Python standard library only
- create an expiring CloudGeni AWS credential lease, start an agent session, poll canonical run output, and purge all temporary state
- extend the Codex adapter with Azure OpenAI Responses-provider support for same-model control runs
- add paired-run Markdown/JSON comparison tooling
- document configuration, security behavior, execution, and teardown

The corresponding CloudGeni product surface is in Cloudgeni-ai/cloudgeni#1816.

## Benchmark evidence

The `aws-bench-quickstart` dataset was run once per arm using GPT-5.6 Sol with medium reasoning:

| Arm | Passed | Exceptions | Mean agent latency |
| --- | ---: | ---: | ---: |
| CloudGeni | 8/9 | 0 | 77.3s |
| Generic Codex | 9/9 | 0 | 69.0s |

The one differing task was unused security-group enumeration: CloudGeni returned the unattached custom group but omitted six unattached default groups. This demonstrated an agent selection-semantics issue rather than adapter or credential failure.

## Security

- credentials remain in environment variables and request bodies; they are never written to adapter state
- CloudGeni leases require an expiration and benchmark run ID
- cleanup runs in `finally` and removes both session and lease
- saved adapter state contains only non-secret identifiers and cleanup status
- Azure and Bedrock Codex provider modes are mutually exclusive

## Verification

- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run pyright`
- `uv run pytest tests/agents/test_cloudgeni.py tests/agents/test_cloudgeni_runner.py tests/agents/test_codex.py -q` — 20 passed
- full repository suite before the final provider delta — 2,996 passed
- rebased onto current upstream `main`
- actual paired 9-task benchmark runs completed with zero adapter exceptions
- AWS-Bench cleanup terminal audit: 3/3 stacks deleted, zero orphaned resources