### PR TITLE
Correct --scenario-path help text

### DIFF
--- a/aws_bench/cli/shared_options.py
+++ b/aws_bench/cli/shared_options.py
@@ -18,8 +18,9 @@ ScenarioPathOption = Annotated[
     Option(
         "--scenario-path",
         help=(
-            "Path to a directory of scenarios (or a single scenario directory). "
-            "Mutually exclusive with --dataset."
+            "Path to a directory containing scenario directories (each "
+            "immediate subdirectory is treated as one scenario). Mutually "
+            "exclusive with --dataset."
         ),
         rich_help_panel="Scenario Source",
         show_default=False,


### PR DESCRIPTION
## Summary

Corrects the `--scenario-path` CLI help text, which was misleading.

It said "Path to a directory of scenarios (or a single scenario directory)", but the local resolver (`_get_local_scenario_configs`) always iterates the **immediate children** of the path and treats each as a scenario — for both `run` and `env`. Pointing `--scenario-path` at a single scenario directory therefore resolves **zero** scenarios (it iterates that scenario's internals like `deploy/`, `scenario/`), and the command silently does nothing.

Reworded to: "Path to a directory containing scenario directories (each immediate subdirectory is treated as one scenario). Mutually exclusive with --dataset."

Docstring-only change; no behavior change.

## Testing

- `make lint`, `make format-check`, `make typecheck`: clean.
- CLI test suite passes.

## Blocked features

None.
