### PR TITLE
refactor(credentials): neutralize STS session-name prefix

### DIFF
--- a/aws_bench/resource_management/constants.py
+++ b/aws_bench/resource_management/constants.py
@@ -1,5 +1,5 @@
 """Constants for resource management."""
 
 # Session-name segment for resource-management STS calls, composed by
-# build_session_name as ``aws-bench-rm-<action>`` (e.g. aws-bench-rm-cleanup).
+# build_session_name as ``app-rm-<action>`` (e.g. app-rm-cleanup).
 RESOURCE_MANAGEMENT_SESSION = "rm"

--- a/aws_bench/resource_management/fastscan/lambda_handler.py
+++ b/aws_bench/resource_management/fastscan/lambda_handler.py
@@ -36,13 +36,14 @@ def _session_for_account(account_id: str, region: str) -> boto3.Session:
     Uses a raw STS call (only boto3) so the handler's import stays free of the
     credential-provider chain, which pulls heavy deps (harbor/pydantic/rich) absent in the
     Lambda runtime. The org role is assumed unscoped, matching the host scan path. A short
-    duration bounds the credential lifetime. The ``aws-bench-`` session-name prefix (built
-    inline; the shared builder is host-only) makes the assume attributable in CloudTrail.
+    duration bounds the credential lifetime. The ``app-`` session-name prefix (built
+    inline; the shared builder is host-only) makes the assume attributable in CloudTrail
+    while staying neutral (it must not reveal aws-bench to an evaluated agent).
     """
     sts = boto3.client("sts")
     resp = sts.assume_role(
         RoleArn=f"arn:aws:iam::{account_id}:role/{ORG_ACCESS_ROLE}",
-        RoleSessionName=f"aws-bench-fastscan-{account_id[-6:]}",
+        RoleSessionName=f"app-fastscan-{account_id[-6:]}",
         DurationSeconds=SCAN_ASSUME_ROLE_DURATION_S,
     )
     creds = resp["Credentials"]

--- a/aws_bench/scenario/provisioning.py
+++ b/aws_bench/scenario/provisioning.py
@@ -66,7 +66,7 @@ from aws_bench.scenario.exceptions import (
 )
 from aws_bench.scenario.job import ScenarioJob
 from aws_bench.scenario.scenario import Scenario
-from aws_bench.utils.credentials_provider import CredentialProvider
+from aws_bench.utils.credentials_provider import CredentialProvider, build_session_name
 
 logger = get_logger(__name__)
 
@@ -596,7 +596,7 @@ def _ensure_cfn_ops_role(cred_provider: CredentialProvider, account_id: str) -> 
     bootstrap cfn-exec role. AdministratorAccess — same scope as cfn-exec.
     """
     session = cred_provider.get_session_for_account(
-        account_id, ORG_ACCESS_ROLE, "aws-bench-cfn-ops-role-setup"
+        account_id, ORG_ACCESS_ROLE, build_session_name("cfn-ops-role-setup")
     )
     iam = session.client("iam")
 
@@ -632,7 +632,7 @@ def _ensure_cfn_ops_role(cred_provider: CredentialProvider, account_id: str) -> 
 def _validate_cfn_ops_role(cred_provider: CredentialProvider, account_id: str) -> None:
     """Validate the externally managed CloudFormation execution role exists."""
     session = cred_provider.get_session_for_account(
-        account_id, ORG_ACCESS_ROLE, "aws-bench-cfn-ops-role-validate"
+        account_id, ORG_ACCESS_ROLE, build_session_name("cfn-ops-role-validate")
     )
     session.client("iam").get_role(RoleName=effective_cfn_role())
 
@@ -670,7 +670,7 @@ async def _provision_account_lifecycle(
                 session = cred_provider.get_session_for_account(
                     account_id,
                     ORG_ACCESS_ROLE,
-                    "aws-bench-runner-role-validate",
+                    build_session_name("runner-role-validate"),
                 )
                 await asyncio.to_thread(session.client("sts").get_caller_identity)
             except Exception as exc:  # noqa: BLE001

--- a/aws_bench/task/aws_creds.py
+++ b/aws_bench/task/aws_creds.py
@@ -20,7 +20,7 @@ logger = get_logger(__name__)
 def session_name(*, task_name: str, role_type: RoleType, job_id: UUID | None) -> str:
     r"""Build an STS RoleSessionName for CloudTrail auditing (<=64 chars, [\w+=,.@-]).
 
-    Ordered ``aws-bench-<role>-<task>-<job>`` so that if the name exceeds 64 chars,
+    Ordered ``app-<role>-<task>-<job>`` so that if the name exceeds 64 chars,
     ``build_session_name``'s trim drops the job-id tail rather than the
     audit-meaningful role and task. '/' in an org/name task name becomes '-'
     (STS allows only [\w+=,.@-]).

--- a/aws_bench/utils/credentials_provider.py
+++ b/aws_bench/utils/credentials_provider.py
@@ -37,24 +37,25 @@ def _apply_client_defaults(session: boto3.Session) -> boto3.Session:
 
 
 # Building blocks for STS RoleSessionNames. Every name is composed as
-# ``aws-bench[-<segment>...]`` so CloudTrail entries are uniformly attributable
-# to the tool. ``AWS_BENCH_PREFIX`` is the single source of truth for that prefix.
-AWS_BENCH_PREFIX = "aws-bench"
+# ``app[-<segment>...]`` so CloudTrail entries are uniformly attributable and the
+# name stays neutral — it must not reveal to an evaluated agent that it is running
+# inside aws-bench. ``SESSION_NAME_PREFIX`` is the single source of truth.
+SESSION_NAME_PREFIX = "app"
 # STS caps RoleSessionName at 64 chars.
 MAX_SESSION_NAME_LEN = 64
 
 
 def build_session_name(*segments: str) -> str:
-    """Compose an ``aws-bench``-prefixed STS RoleSessionName from ``segments``.
+    """Compose a ``SESSION_NAME_PREFIX``-prefixed STS RoleSessionName from ``segments``.
 
-    Joins ``AWS_BENCH_PREFIX`` and ``segments`` with ``-`` and truncates to STS's
+    Joins ``SESSION_NAME_PREFIX`` and ``segments`` with ``-`` and truncates to STS's
     64-char limit. This is the single constructor for session names, so the
-    CloudTrail-attribution prefix lives in exactly one place.
+    prefix lives in exactly one place.
 
     Example:
-        ``build_session_name("rm", "cleanup")`` -> ``"aws-bench-rm-cleanup"``
+        ``build_session_name("rm", "cleanup")`` -> ``"app-rm-cleanup"``
     """
-    return "-".join([AWS_BENCH_PREFIX, *segments])[:MAX_SESSION_NAME_LEN]
+    return "-".join([SESSION_NAME_PREFIX, *segments])[:MAX_SESSION_NAME_LEN]
 
 
 def enforce_session_name(session_name: str) -> str:
@@ -62,16 +63,16 @@ def enforce_session_name(session_name: str) -> str:
 
     Backstop at the generic STS choke points all assume-role paths funnel
     through: even a hand-written name (not built via :func:`build_session_name`)
-    must carry the ``aws-bench-`` prefix, so the convention is enforced at runtime.
+    must carry the ``app-`` prefix, so the convention is enforced at runtime.
 
     Returns the name truncated to STS's 64-char limit; callers historically
-    relied on this truncation (e.g. the ``aws-bench-<role>-<task>-<job>`` builder
+    relied on this truncation (e.g. the ``app-<role>-<task>-<job>`` builder
     drops its job-id tail rather than the audit-meaningful prefix).
 
     Raises:
-        ValueError: If the name does not start with ``aws-bench-``.
+        ValueError: If the name does not start with ``app-``.
     """
-    required_prefix = AWS_BENCH_PREFIX + "-"
+    required_prefix = SESSION_NAME_PREFIX + "-"
     if not session_name.startswith(required_prefix):
         raise ValueError(
             f"RoleSessionName must start with {required_prefix!r} for CloudTrail "

--- a/docs/datasets-development.md
+++ b/docs/datasets-development.md
@@ -325,7 +325,7 @@ description = "Short description of what the agent must do"
 
 [scenario]
 scenario_id = "my-scenario"
-agent_role_name = "QALocalInvocationApplicationRole"
+agent_role_name = "ApplicationReadOnlyRole"
 
 [metadata]
 id = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"

--- a/tests/resource_management/fastscan/test_lambda_handler.py
+++ b/tests/resource_management/fastscan/test_lambda_handler.py
@@ -63,5 +63,5 @@ def test_session_for_account_assumes_org_role_with_attribution(mocker):
     assert "PolicyArns" not in kwargs
     # Short-lived creds bound the credential lifetime.
     assert kwargs["DurationSeconds"] == constants.SCAN_ASSUME_ROLE_DURATION_S
-    # Session name carries the aws-bench- prefix for CloudTrail attribution.
-    assert kwargs["RoleSessionName"].startswith("aws-bench-")
+    # Session name carries the app- prefix for CloudTrail attribution.
+    assert kwargs["RoleSessionName"].startswith("app-")

--- a/tests/resource_management/test_manager.py
+++ b/tests/resource_management/test_manager.py
@@ -51,7 +51,7 @@ def test_cleanup_account_creates_cleanup_manager_and_delegates():
         result = asyncio.run(ResourceManager.cleanup_account("123456789012", regions=["us-east-1"]))
 
         mock_cred_provider.get_session_for_account.assert_called_once_with(
-            "123456789012", "OrganizationAccountAccessRole", "aws-bench-rm-cleanup-account"
+            "123456789012", "OrganizationAccountAccessRole", "app-rm-cleanup-account"
         )
         mock_cleanup_cls.assert_called_once_with(
             mock_session, env_name=None, account_id="123456789012"
@@ -109,7 +109,7 @@ def test_cleanup_stack_creates_cleanup_manager_and_delegates():
         result = asyncio.run(ResourceManager.cleanup_stack("123456789012", "my-stack"))
 
         mock_cred_provider.get_session_for_account.assert_called_once_with(
-            "123456789012", "OrganizationAccountAccessRole", "aws-bench-rm-cleanup-stack"
+            "123456789012", "OrganizationAccountAccessRole", "app-rm-cleanup-stack"
         )
         mock_cleanup_cls.assert_called_once_with(mock_session, account_id="123456789012")
         mock_cleanup_manager.cleanup_stack.assert_called_once_with("my-stack")

--- a/tests/task/test_aws_creds.py
+++ b/tests/task/test_aws_creds.py
@@ -16,14 +16,14 @@ def test_session_name_includes_job_id_when_set():
     )
     # '/' is replaced with '-' (STS session names allow only [\w+=,.@-]).
     assert "org-my-task" in name
-    # Ordered aws-bench-<role>-<task>-<job>: role leads so a trim drops the job tail.
-    assert name.startswith(f"aws-bench-{RoleType.AGENT}-")
+    # Ordered app-<role>-<task>-<job>: role leads so a trim drops the job tail.
+    assert name.startswith(f"app-{RoleType.AGENT}-")
     assert str(UUID(int=1)) in name
 
 
 def test_session_name_omits_job_id_when_none():
     name = aws_creds.session_name(task_name="org/my-task", role_type=RoleType.VERIFIER, job_id=None)
-    assert name == "aws-bench-verifier-org-my-task"
+    assert name == "app-verifier-org-my-task"
 
 
 def test_resolve_env_with_creds_substitutes_then_appends_creds():
@@ -87,7 +87,7 @@ def test_assume_role_for_script_falls_back_to_org_access_role(mocker):
 @pytest.mark.parametrize("role_type", list(RoleType))
 def test_session_name_role_types(role_type):
     name = aws_creds.session_name(task_name="t", role_type=role_type, job_id=None)
-    assert name.startswith(f"aws-bench-{role_type}-")
+    assert name.startswith(f"app-{role_type}-")
 
 
 def test_session_name_overflow_trims_to_64_keeping_role_and_task():
@@ -98,6 +98,6 @@ def test_session_name_overflow_trims_to_64_keeping_role_and_task():
     )
     assert len(name) == 64
     # Role and the (start of the) task survive the trim; the job-id tail is cut.
-    assert name.startswith("aws-bench-verifier-some-org-aaa")
+    assert name.startswith("app-verifier-some-org-aaa")
     # STS charset: [\w+=,.@-]. '/' must have been replaced.
     assert "/" not in name

--- a/tests/utils/test_credentials_provider.py
+++ b/tests/utils/test_credentials_provider.py
@@ -9,8 +9,8 @@ import boto3
 import pytest
 
 from aws_bench.utils.credentials_provider import (
-    AWS_BENCH_PREFIX,
     MAX_SESSION_NAME_LEN,
+    SESSION_NAME_PREFIX,
     CredentialProvider,
     _create_refreshable_session,
     build_aws_credentials_file,
@@ -111,7 +111,7 @@ def test_assume_role_returns_credentials():
         }
     }
     provider = CredentialProvider(session=mock_session)
-    creds = provider.assume_role("111111111111", "TestRole", "aws-bench-test-session")
+    creds = provider.assume_role("111111111111", "TestRole", "app-test-session")
 
     assert creds["AWS_ACCESS_KEY_ID"] == "AKIA_TEST"
     assert creds["AWS_SECRET_ACCESS_KEY"] == "SECRET_TEST"
@@ -126,7 +126,7 @@ def test_assume_role_truncates_session_name_to_64_chars():
         "Credentials": {"AccessKeyId": "AK", "SecretAccessKey": "SK", "SessionToken": "ST"}
     }
     provider = CredentialProvider(session=mock_session)
-    provider.assume_role("111111111111", "TestRole", "aws-bench-" + "a" * 100)
+    provider.assume_role("111111111111", "TestRole", "app-" + "a" * 100)
 
     call_kwargs = mock_sts.assume_role.call_args[1]
     assert len(call_kwargs["RoleSessionName"]) == 64
@@ -151,7 +151,7 @@ def test_create_refreshable_session_returns_session():
     }
 
     session = _create_refreshable_session(
-        mock_parent_session, "arn:aws:iam::123456789012:role/TestRole", "aws-bench-test-session"
+        mock_parent_session, "arn:aws:iam::123456789012:role/TestRole", "app-test-session"
     )
 
     assert isinstance(session, boto3.Session)
@@ -176,7 +176,7 @@ def test_create_refreshable_session_uses_correct_params():
     session = _create_refreshable_session(
         mock_parent_session,
         "arn:aws:iam::123456789012:role/TestRole",
-        "aws-bench-test-session-name",
+        "app-test-session-name",
     )
 
     # Trigger credential fetch by accessing credentials
@@ -187,7 +187,7 @@ def test_create_refreshable_session_uses_correct_params():
     mock_sts.assume_role.assert_called_once()
     call_kwargs = mock_sts.assume_role.call_args.kwargs
     assert call_kwargs["RoleArn"] == "arn:aws:iam::123456789012:role/TestRole"
-    assert call_kwargs["RoleSessionName"] == "aws-bench-test-session-name"
+    assert call_kwargs["RoleSessionName"] == "app-test-session-name"
 
 
 def test_create_refreshable_session_creates_fresh_sts_client_on_each_refresh():
@@ -217,7 +217,7 @@ def test_create_refreshable_session_creates_fresh_sts_client_on_each_refresh():
     mock_parent_session.client.side_effect = make_sts
 
     session = _create_refreshable_session(
-        mock_parent_session, "arn:aws:iam::123456789012:role/TestRole", "aws-bench-test-session"
+        mock_parent_session, "arn:aws:iam::123456789012:role/TestRole", "app-test-session"
     )
 
     # First credential fetch creates first STS client
@@ -245,11 +245,11 @@ def test_get_session_for_account_returns_session(mock_create_session):
     mock_create_session.return_value = mock_created_session
 
     provider = CredentialProvider(session=mock_session)
-    result = provider.get_session_for_account("111111111111", "TestRole", "aws-bench-sess")
+    result = provider.get_session_for_account("111111111111", "TestRole", "app-sess")
 
     assert result is mock_created_session
     mock_create_session.assert_called_once_with(
-        mock_session, "arn:aws:iam::111111111111:role/TestRole", "aws-bench-sess", "us-east-1"
+        mock_session, "arn:aws:iam::111111111111:role/TestRole", "app-sess", "us-east-1"
     )
 
 
@@ -269,7 +269,7 @@ def test_chain_assume_role_without_role_returns_org_creds(mock_session_cls):
         }
     }
     provider = CredentialProvider(session=mock_session)
-    creds = provider.chain_assume_role(account_id="111111111111", session_name="aws-bench-sess")
+    creds = provider.chain_assume_role(account_id="111111111111", session_name="app-sess")
 
     assert creds["AWS_ACCESS_KEY_ID"] == "ORG_AK"
     mock_sts.assume_role.assert_called_once()  # only hop 1
@@ -291,12 +291,12 @@ def test_chain_assume_role_with_org_role_skips_second_hop(mock_session_cls):
     }
     provider = CredentialProvider(session=mock_session)
     creds = provider.chain_assume_role(
-        account_id="111111111111", session_name="aws-bench-sess", role_name=ORG_ACCESS_ROLE
+        account_id="111111111111", session_name="app-sess", role_name=ORG_ACCESS_ROLE
     )
 
     assert creds["AWS_ACCESS_KEY_ID"] == "ORG_AK"
     mock_sts.assume_role.assert_called_once()  # only hop 1
-    assert mock_sts.assume_role.call_args.kwargs["RoleSessionName"] == "aws-bench-sess"
+    assert mock_sts.assume_role.call_args.kwargs["RoleSessionName"] == "app-sess"
 
 
 @patch("aws_bench.utils.credentials_provider.boto3.Session")
@@ -324,7 +324,7 @@ def test_chain_assume_role_with_role_performs_two_hops(mock_session_cls):
 
     provider = CredentialProvider(session=mock_session)
     creds = provider.chain_assume_role(
-        account_id="111111111111", session_name="aws-bench-sess", role_name="TaskRole"
+        account_id="111111111111", session_name="app-sess", role_name="TaskRole"
     )
 
     assert creds["AWS_ACCESS_KEY_ID"] == "TASK_AK"
@@ -349,7 +349,7 @@ def test_chain_assume_role_first_hop_failure(mock_session_cls):
 
     with pytest.raises(ClientError):
         provider.chain_assume_role(
-            account_id="111111111111", session_name="aws-bench-sess", role_name="TaskRole"
+            account_id="111111111111", session_name="app-sess", role_name="TaskRole"
         )
 
 
@@ -379,7 +379,7 @@ def test_chain_assume_role_second_hop_failure(mock_session_cls):
 
     with pytest.raises(ClientError):
         provider.chain_assume_role(
-            account_id="111111111111", session_name="aws-bench-sess", role_name="TaskRole"
+            account_id="111111111111", session_name="app-sess", role_name="TaskRole"
         )
 
 
@@ -403,7 +403,7 @@ def test_create_regional_session_shares_credentials():
 
     # Create parent session with refreshable credentials
     parent_session = _create_refreshable_session(
-        mock_parent_session, "arn:aws:iam::123456789012:role/TestRole", "aws-bench-test-session"
+        mock_parent_session, "arn:aws:iam::123456789012:role/TestRole", "app-test-session"
     )
 
     # Create regional session
@@ -431,7 +431,7 @@ def test_create_regional_session_preserves_refreshable_credentials():
 
     # Create parent session
     parent_session = _create_refreshable_session(
-        mock_parent_session, "arn:aws:iam::123456789012:role/TestRole", "aws-bench-test-session"
+        mock_parent_session, "arn:aws:iam::123456789012:role/TestRole", "app-test-session"
     )
 
     # Get credentials from parent
@@ -622,7 +622,7 @@ def test_regional_session_stamps_adaptive_retry_default():
         }
     }
     session = _create_refreshable_session(
-        mock_parent, "arn:aws:iam::123456789012:role/TestRole", "aws-bench-test"
+        mock_parent, "arn:aws:iam::123456789012:role/TestRole", "app-test"
     )
     regional = create_regional_session(session, "us-west-2")
 
@@ -648,7 +648,7 @@ def test_explicit_client_config_overrides_retry_default():
         }
     }
     session = _create_refreshable_session(
-        mock_parent, "arn:aws:iam::123456789012:role/TestRole", "aws-bench-test"
+        mock_parent, "arn:aws:iam::123456789012:role/TestRole", "app-test"
     )
 
     # A timeout-only config keeps the inherited adaptive retries (field-by-field merge).
@@ -783,22 +783,22 @@ def test_build_aws_credentials_file_empty_mapping_returns_empty_string():
 
 
 def test_build_session_name_prepends_prefix_and_joins():
-    """Composes aws-bench-<segments> with hyphens from the shared prefix constant."""
-    assert build_session_name("rm", "cleanup") == "aws-bench-rm-cleanup"
-    assert build_session_name("quota", "verify", "123456") == "aws-bench-quota-verify-123456"
-    assert build_session_name("show") == "aws-bench-show"
+    """Composes app-<segments> with hyphens from the shared prefix constant."""
+    assert build_session_name("rm", "cleanup") == "app-rm-cleanup"
+    assert build_session_name("quota", "verify", "123456") == "app-quota-verify-123456"
+    assert build_session_name("show") == "app-show"
 
 
 def test_build_session_name_uses_prefix_constant():
-    """The prefix comes from AWS_BENCH_PREFIX, the single source of truth."""
-    assert build_session_name("x").startswith(AWS_BENCH_PREFIX + "-")
+    """The prefix comes from SESSION_NAME_PREFIX, the single source of truth."""
+    assert build_session_name("x").startswith(SESSION_NAME_PREFIX + "-")
 
 
 def test_build_session_name_truncates_to_sts_limit():
     """Composed names are truncated to STS's 64-char limit."""
     result = build_session_name("a" * 100)
     assert len(result) == MAX_SESSION_NAME_LEN
-    assert result.startswith("aws-bench-")
+    assert result.startswith("app-")
 
 
 def test_build_session_name_output_passes_enforce():
@@ -813,23 +813,23 @@ def test_build_session_name_output_passes_enforce():
 @pytest.mark.parametrize(
     "name",
     [
-        "aws-bench-rm-cleanup",
-        "aws-bench-rm-cleanup-stack",
-        "aws-bench-rm-reset",
-        "aws-bench-rm-verify",
-        "aws-bench-rm-snapshot-post_setup",
-        "aws-bench-role-probe",
-        "aws-bench-show",
-        "aws-bench-exports-123456",
-        "aws-bench-quota-123456",
-        "aws-bench-quota-verify-123456",
-        "aws-bench-quota-show-123456",
-        "aws-bench-org-123456",
-        "aws-bench-agent-aws-introspection-list-ec-instances",
+        "app-rm-cleanup",
+        "app-rm-cleanup-stack",
+        "app-rm-reset",
+        "app-rm-verify",
+        "app-rm-snapshot-post_setup",
+        "app-role-probe",
+        "app-show",
+        "app-exports-123456",
+        "app-quota-123456",
+        "app-quota-verify-123456",
+        "app-quota-show-123456",
+        "app-org-123456",
+        "app-agent-aws-introspection-list-ec-instances",
     ],
 )
 def test_enforce_session_name_accepts_convention(name):
-    """Every name following the aws-bench- convention passes through unchanged."""
+    """Every name following the app- convention passes through unchanged."""
     assert enforce_session_name(name) == name
 
 
@@ -848,17 +848,17 @@ def test_enforce_session_name_accepts_convention(name):
     ],
 )
 def test_enforce_session_name_rejects_missing_prefix(name):
-    """Names without the aws-bench- prefix are rejected before reaching STS."""
-    with pytest.raises(ValueError, match="must start with 'aws-bench-'"):
+    """Names without the app- prefix are rejected before reaching STS."""
+    with pytest.raises(ValueError, match="must start with 'app-'"):
         enforce_session_name(name)
 
 
 def test_enforce_session_name_truncates_to_sts_limit():
     """Over-long names are truncated to STS's 64-char limit, prefix preserved."""
-    long_name = "aws-bench-" + "a" * 100
+    long_name = "app-" + "a" * 100
     result = enforce_session_name(long_name)
     assert len(result) == MAX_SESSION_NAME_LEN
-    assert result.startswith("aws-bench-")
+    assert result.startswith("app-")
 
 
 def test_assume_role_enforces_session_name_convention():
@@ -869,7 +869,7 @@ def test_assume_role_enforces_session_name_convention():
     """
     mock_session = MagicMock()
     provider = CredentialProvider(session=mock_session)
-    with pytest.raises(ValueError, match="must start with 'aws-bench-'"):
+    with pytest.raises(ValueError, match="must start with 'app-'"):
         provider.assume_role("123456789012", "SomeRole", "bad-session-name")
     # STS must never be invoked with an invalid session name.
     mock_session.client.return_value.assume_role.assert_not_called()

--- a/tests/utils/test_preexisting_credentials.py
+++ b/tests/utils/test_preexisting_credentials.py
@@ -41,12 +41,12 @@ def test_org_access_role_maps_directly_to_runner_role(tmp_path: Path, monkeypatc
         "aws_bench.utils.credentials_provider._create_refreshable_session"
     ) as create_session:
         provider.get_session_for_account(
-            "111122223333", "OrganizationAccountAccessRole", "aws-bench-test"
+            "111122223333", "OrganizationAccountAccessRole", "app-test"
         )
     create_session.assert_called_once_with(
         session,
         "arn:aws:iam::111122223333:role/AWSBenchRunner",
-        "aws-bench-test",
+        "app-test",
         "us-east-1",
     )
 
@@ -57,19 +57,19 @@ def test_explicit_task_role_chains_from_configured_runner(tmp_path: Path, monkey
     with patch(
         "aws_bench.utils.credentials_provider._create_refreshable_session"
     ) as create_session:
-        provider.get_session_for_account("111122223333", "TaskRole", "aws-bench-task")
+        provider.get_session_for_account("111122223333", "TaskRole", "app-task")
     assert create_session.call_count == 2
     runner_session = create_session.return_value
     assert create_session.call_args_list[0].args == (
         session,
         "arn:aws:iam::111122223333:role/AWSBenchRunner",
-        "aws-bench-runner-223333",
+        "app-runner-223333",
         "us-east-1",
     )
     assert create_session.call_args_list[1].args == (
         runner_session,
         "arn:aws:iam::111122223333:role/TaskRole",
-        "aws-bench-task",
+        "app-task",
         "us-east-1",
     )
 
@@ -84,7 +84,7 @@ def test_already_active_runner_role_is_not_self_assumed(tmp_path: Path, monkeypa
         patch("aws_bench.utils.credentials_provider.create_regional_session") as regional,
     ):
         provider.get_session_for_account(
-            "111122223333", "OrganizationAccountAccessRole", "aws-bench-test"
+            "111122223333", "OrganizationAccountAccessRole", "app-test"
         )
     create.assert_not_called()
     regional.assert_called_once_with(session, "us-east-1")
@@ -106,10 +106,10 @@ def test_unnamed_role_assumes_runner_not_caller_credentials(tmp_path: Path, monk
         }
     )
 
-    credentials = provider.chain_assume_role("111122223333", "aws-bench-task", role_name=None)
+    credentials = provider.chain_assume_role("111122223333", "app-task", role_name=None)
 
     provider.assume_role.assert_called_once_with(
-        "111122223333", "AWSBenchRunner", "aws-bench-task", duration_seconds=3600
+        "111122223333", "AWSBenchRunner", "app-task", duration_seconds=3600
     )
     assert credentials["AWS_ACCESS_KEY_ID"] == "runner-key"
 
@@ -118,7 +118,7 @@ def test_account_outside_allowlist_is_refused(tmp_path: Path, monkeypatch):
     _activate(tmp_path, monkeypatch)
     provider, _ = _provider()
     with pytest.raises(AccountResolutionError, match="not in the active pre-existing allowlist"):
-        provider.chain_assume_role("999988887777", "aws-bench-test")
+        provider.chain_assume_role("999988887777", "app-test")
 
 
 def test_static_task_credentials_chain_through_runner(tmp_path: Path, monkeypatch):
@@ -144,18 +144,16 @@ def test_static_task_credentials_chain_through_runner(tmp_path: Path, monkeypatc
         "aws_bench.utils.credentials_provider.env_credentials_dict_to_session",
         return_value=runner_session,
     ):
-        credentials = provider.chain_assume_role(
-            "111122223333", "aws-bench-task", role_name="TaskRole"
-        )
+        credentials = provider.chain_assume_role("111122223333", "app-task", role_name="TaskRole")
     provider.assume_role.assert_called_once_with(
         "111122223333",
         "AWSBenchRunner",
-        "aws-bench-runner-223333",
+        "app-runner-223333",
         duration_seconds=3600,
     )
     runner_sts.assume_role.assert_called_once_with(
         RoleArn="arn:aws:iam::111122223333:role/TaskRole",
-        RoleSessionName="aws-bench-task",
+        RoleSessionName="app-task",
         DurationSeconds=3600,
     )
     assert credentials["AWS_ACCESS_KEY_ID"] == "task-key"


### PR DESCRIPTION
### Description of changes:
Rename the STS RoleSessionName prefix from `aws-bench` to the neutral `app` (single source of truth `SESSION_NAME_PREFIX`). Previously an evaluated agent could read `arn:...:assumed-role/<role>/aws-bench-agent-...` via sts:GetCallerIdentity and infer it was running inside the benchmark.

Also route the hardcoded provisioning session-name literals through `build_session_name` and update the fastscan Lambda's inline prefix, since both flow through / mirror the enforced prefix.

Includes an unrelated docs update (agent_role_name example).




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
